### PR TITLE
feat: reintrocues CheckForCorrectness

### DIFF
--- a/aleo-setup1/src/bin/prepare_phase2.rs
+++ b/aleo-setup1/src/bin/prepare_phase2.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+use setup_utils::CheckForCorrectness;
 
 cfg_if! {
     if #[cfg(not(feature = "wasm"))] {
@@ -62,7 +63,7 @@ cfg_if! {
                 .expect("unable to create parameter file in this directory");
 
             // Deserialize the accumulator
-            let current_accumulator = Phase1::deserialize(&response_readable_map, UseCompression::Yes, &parameters)
+            let current_accumulator = Phase1::deserialize(&response_readable_map, UseCompression::Yes, CheckForCorrectness::Yes, &parameters)
                 .expect("unable to read uncompressed accumulator");
 
             // Load the elements to the Groth16 utility

--- a/aleo-setup1/src/cli/contribute.rs
+++ b/aleo-setup1/src/cli/contribute.rs
@@ -1,5 +1,5 @@
 use phase1::{Phase1, Phase1Parameters};
-use setup_utils::{calculate_hash, print_hash, UseCompression};
+use setup_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompression};
 
 use zexe_algebra::PairingEngine as Engine;
 
@@ -12,6 +12,7 @@ use std::{
 
 const COMPRESSED_INPUT: UseCompression = UseCompression::No;
 const COMPRESSED_OUTPUT: UseCompression = UseCompression::Yes;
+const CHECK_INPUT_CORRECTNESS: CheckForCorrectness = CheckForCorrectness::No;
 
 pub fn contribute<T: Engine + Sync>(
     challenge_filename: &str,
@@ -116,6 +117,7 @@ pub fn contribute<T: Engine + Sync>(
         &mut writable_map,
         COMPRESSED_INPUT,
         COMPRESSED_OUTPUT,
+        CHECK_INPUT_CORRECTNESS,
         &private_key,
         &parameters,
     )

--- a/aleo-setup1/src/cli/transform.rs
+++ b/aleo-setup1/src/cli/transform.rs
@@ -1,5 +1,5 @@
 use phase1::{Phase1, Phase1Parameters, PublicKey};
-use setup_utils::{calculate_hash, print_hash, UseCompression};
+use setup_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompression};
 
 use zexe_algebra::PairingEngine as Engine;
 
@@ -129,6 +129,8 @@ pub fn transform<T: Engine + Sync>(
         current_accumulator_hash.as_slice(),
         PREVIOUS_CHALLENGE_IS_COMPRESSED,
         CONTRIBUTION_IS_COMPRESSED,
+        CheckForCorrectness::No,
+        CheckForCorrectness::Yes,
         &parameters,
     );
 
@@ -173,8 +175,13 @@ pub fn transform<T: Engine + Sync>(
                 .expect("unable to write hash to new challenge file");
         }
 
-        Phase1::decompress(&response_readable_map, &mut writable_map, &parameters)
-            .expect("must decompress a response for a new challenge");
+        Phase1::decompress(
+            &response_readable_map,
+            &mut writable_map,
+            CheckForCorrectness::No,
+            &parameters,
+        )
+        .expect("must decompress a response for a new challenge");
 
         writable_map.flush().expect("must flush the memory map");
 

--- a/aleo-setup2/src/cli/new.rs
+++ b/aleo-setup2/src/cli/new.rs
@@ -1,5 +1,5 @@
 use phase2::parameters::{circuit_to_qap, MPCParameters};
-use setup_utils::{log_2, Groth16Params, UseCompression};
+use setup_utils::{log_2, CheckForCorrectness, Groth16Params, UseCompression};
 
 use zexe_algebra::{Bls12_377, PairingEngine, BW6_761};
 
@@ -175,6 +175,7 @@ pub fn generate_params<Aleo: AleoPairingengine, Zexe: PairingEngine, C: Clone + 
     let phase1 = Groth16Params::<Zexe>::read(
         &mut phase1_transcript,
         COMPRESSION,
+        CheckForCorrectness::No,
         2usize.pow(opt.phase1_size),
         phase2_size,
     )?;

--- a/phase1/benches/phase1.rs
+++ b/phase1/benches/phase1.rs
@@ -65,6 +65,7 @@ fn benchmark_computation(c: &mut Criterion) {
                         &mut output,
                         compressed_input,
                         compressed_output,
+                        CheckForCorrectness::Yes,
                         &private_key,
                         &parameters,
                     )
@@ -79,6 +80,8 @@ fn benchmark_computation(c: &mut Criterion) {
 // compressed situations. Parallel verification is consistently faster by 10-15% in all
 // modes of operation
 fn benchmark_verification(c: &mut Criterion) {
+    let correctness = CheckForCorrectness::No;
+
     // Iterate over all combinations of the following parameters
     let compression = &[
         (UseCompression::Yes, UseCompression::Yes),
@@ -113,6 +116,8 @@ fn benchmark_verification(c: &mut Criterion) {
                             &current_accumulator_hash,
                             *compressed_input,
                             *compressed_output,
+                            correctness,
+                            correctness,
                             &parameters,
                         )
                         .unwrap()

--- a/phase1/src/helpers/buffers.rs
+++ b/phase1/src/helpers/buffers.rs
@@ -6,7 +6,7 @@ use zexe_algebra::{AffineCurve, PairingEngine};
 use itertools::{Itertools, MinMaxResult};
 
 /// Buffer, compression
-type Input<'a> = (&'a [u8], UseCompression);
+type Input<'a> = (&'a [u8], UseCompression, CheckForCorrectness);
 
 /// Mutable buffer, compression
 type Output<'a> = (&'a mut [u8], UseCompression);
@@ -41,7 +41,7 @@ pub(crate) fn iter_chunk(
 /// provided `powers` and maybe to the `coeff`, and then writes them back
 pub(crate) fn apply_powers<C: AffineCurve>(
     (output, output_compressed): Output,
-    (input, input_compressed): Input,
+    (input, input_compressed, check_input_for_correctness): Input,
     (start, end): (usize, usize),
     powers: &[C::ScalarField],
     coeff: Option<&C::ScalarField>,
@@ -49,7 +49,8 @@ pub(crate) fn apply_powers<C: AffineCurve>(
     let in_size = buffer_size::<C>(input_compressed);
     let out_size = buffer_size::<C>(output_compressed);
     // read the input
-    let mut elements = &mut input[start * in_size..end * in_size].read_batch::<C>(input_compressed)?;
+    let mut elements =
+        &mut input[start * in_size..end * in_size].read_batch::<C>(input_compressed, check_input_for_correctness)?;
     // calculate the powers
     batch_exp(&mut elements, &powers[..end - start], coeff)?;
     // write back

--- a/phase1/src/initialization.rs
+++ b/phase1/src/initialization.rs
@@ -71,7 +71,7 @@ mod tests {
         let mut output = vec![0; expected_challenge_length];
         Phase1::initialization(&mut output, compression, &parameters).unwrap();
 
-        let deserialized = Phase1::deserialize(&output, compression, &parameters).unwrap();
+        let deserialized = Phase1::deserialize(&output, compression, CheckForCorrectness::Yes, &parameters).unwrap();
 
         let g1_zero = E::G1Affine::prime_subgroup_generator();
         let g2_zero = E::G2Affine::prime_subgroup_generator();

--- a/phase1/tests/aleo_compatibility.rs
+++ b/phase1/tests/aleo_compatibility.rs
@@ -1,5 +1,5 @@
 use phase1::{helpers::testing::setup_verify, Phase1Parameters};
-use setup_utils::UseCompression;
+use setup_utils::{CheckForCorrectness, UseCompression};
 
 use snarkos_curves::{bls12_377::Bls12_377 as AleoBls12_377, bw6_761::BW6_761 as AleoBW6};
 use snarkos_models::curves::{AffineCurve as AleoAffineCurve, PairingEngine as AleoPairingEngine};
@@ -28,7 +28,7 @@ fn compatible_phase1_test<Aleo: AleoPairingEngine, Zexe: ZexePairingEngine>() ->
 
     // Perform 1 power of tau contribution (assume Powers of Tau is computed correctly)
     let compressed = UseCompression::No;
-    let (_, output, _, _) = setup_verify(compressed, compressed, &params);
+    let (_, output, _, _) = setup_verify(compressed, CheckForCorrectness::Yes, compressed, &params);
 
     // Advance the cursor past the output hash.
     let mut reader = std::io::BufReader::new(std::io::Cursor::new(output));

--- a/phase2/src/keypair.rs
+++ b/phase2/src/keypair.rs
@@ -2,7 +2,7 @@
 //!
 //! A Groth16 keypair. Generate one with the Keypair::new method.
 //! Dispose of the private key ASAP once it's been used.
-use setup_utils::{hash_to_g2, Deserializer, HashWriter, Result, Serializer, UseCompression};
+use setup_utils::{hash_to_g2, CheckForCorrectness, Deserializer, HashWriter, Result, Serializer, UseCompression};
 
 use zexe_algebra::{
     AffineCurve,
@@ -97,10 +97,10 @@ impl<E: PairingEngine> PublicKey<E> {
     /// Reads the key's **uncompressed** points from the provided
     /// reader
     pub fn read<R: Read>(reader: &mut R) -> Result<PublicKey<E>> {
-        let delta_after = reader.read_element(UseCompression::No)?;
-        let s = reader.read_element(UseCompression::No)?;
-        let s_delta = reader.read_element(UseCompression::No)?;
-        let r_delta = reader.read_element(UseCompression::No)?;
+        let delta_after = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let s = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let s_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
+        let r_delta = reader.read_element(UseCompression::No, CheckForCorrectness::Yes)?;
         let mut transcript = [0u8; 64];
         reader.read_exact(&mut transcript)?;
 

--- a/phase2/src/parameters.rs
+++ b/phase2/src/parameters.rs
@@ -63,6 +63,7 @@ impl<E: PairingEngine> MPCParameters<E> {
         circuit: C,
         transcript: &mut [u8],
         compressed: UseCompression,
+        check_input_for_correctness: CheckForCorrectness,
         phase1_size: usize,
         phase2_size: usize,
     ) -> Result<MPCParameters<E>>
@@ -71,7 +72,13 @@ impl<E: PairingEngine> MPCParameters<E> {
         Aleo: AleoPairingEngine,
     {
         let assembly = circuit_to_qap::<Aleo, E, _>(circuit)?;
-        let params = Groth16Params::<E>::read(transcript, compressed, phase1_size, phase2_size)?;
+        let params = Groth16Params::<E>::read(
+            transcript,
+            compressed,
+            check_input_for_correctness,
+            phase1_size,
+            phase2_size,
+        )?;
         Self::new(assembly, params)
     }
 
@@ -550,8 +557,8 @@ mod tests {
         let params = Phase1Parameters::<E>::new(powers, batch);
         let accumulator = {
             let compressed = UseCompression::No;
-            let (_, output, _, _) = setup_verify(compressed, compressed, &params);
-            Phase1::deserialize(&output, compressed, &params).unwrap()
+            let (_, output, _, _) = setup_verify(compressed, CheckForCorrectness::Yes, compressed, &params);
+            Phase1::deserialize(&output, compressed, CheckForCorrectness::Yes, &params).unwrap()
         };
 
         let groth_params = Groth16Params::<E>::new(

--- a/setup-utils/src/elements.rs
+++ b/setup-utils/src/elements.rs
@@ -16,6 +16,22 @@ impl fmt::Display for UseCompression {
     }
 }
 
+/// Determines if points should be checked to be infinity.
+#[derive(Copy, Clone, PartialEq)]
+pub enum CheckForCorrectness {
+    Yes,
+    No,
+}
+
+impl fmt::Display for CheckForCorrectness {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CheckForCorrectness::Yes => write!(f, "Yes"),
+            CheckForCorrectness::No => write!(f, "No"),
+        }
+    }
+}
+
 // todo: remove this, we can always get the size of the element
 // from the `buffer_size` method
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/setup-utils/src/io/mod.rs
+++ b/setup-utils/src/io/mod.rs
@@ -23,6 +23,7 @@ mod tests {
 
     use zexe_algebra::bls12_377::{G1Affine, G2Affine};
 
+    use crate::CheckForCorrectness;
     use rand::thread_rng;
 
     #[test]
@@ -63,7 +64,7 @@ mod tests {
         let mut buf = vec![];
         // assert that the deserialized version is the same as the serialized
         buf.write_element(&el, compression).unwrap();
-        let deserialized: E = buf.read_element(compression).unwrap();
+        let deserialized: E = buf.read_element(compression, CheckForCorrectness::No).unwrap();
         assert_eq!(el, deserialized);
     }
 
@@ -74,7 +75,8 @@ mod tests {
         let mut buf = vec![];
         // assert that the deserialized version is the same as the serialized
         buf.write_element(&el, compression).unwrap();
-        buf.read_element_preallocated(&mut prealloc, compression).unwrap();
+        buf.read_element_preallocated(&mut prealloc, compression, CheckForCorrectness::No)
+            .unwrap();
         assert_eq!(el, prealloc);
     }
 
@@ -87,8 +89,8 @@ mod tests {
         let len = len * num_els;
         let mut buf = vec![0; len];
         buf.write_batch(&elements, compression).unwrap();
-        let deserialized1: Vec<E> = buf.read_batch(compression).unwrap();
-        let deserialized2: Vec<E> = buf.read_batch(compression).unwrap();
+        let deserialized1: Vec<E> = buf.read_batch(compression, CheckForCorrectness::No).unwrap();
+        let deserialized2: Vec<E> = buf.read_batch(compression, CheckForCorrectness::No).unwrap();
         assert_eq!(elements, deserialized1);
         assert_eq!(elements, deserialized2);
     }
@@ -105,8 +107,10 @@ mod tests {
         buf.write_batch(&elements, compression).unwrap();
         let mut prealloc: Vec<E> = random_point_vec(num_els, &mut rng);
         let mut prealloc2: Vec<E> = random_point_vec(num_els, &mut rng);
-        buf.read_batch_preallocated(&mut prealloc, compression).unwrap();
-        buf.read_batch_preallocated(&mut prealloc2, compression).unwrap();
+        buf.read_batch_preallocated(&mut prealloc, compression, CheckForCorrectness::No)
+            .unwrap();
+        buf.read_batch_preallocated(&mut prealloc2, compression, CheckForCorrectness::No)
+            .unwrap();
         assert_eq!(elements, prealloc);
         assert_eq!(elements, prealloc2);
     }

--- a/setup-utils/src/io/read.rs
+++ b/setup-utils/src/io/read.rs
@@ -1,4 +1,4 @@
-use crate::{buffer_size, Result, UseCompression};
+use crate::{buffer_size, CheckForCorrectness, Error, Result, UseCompression};
 
 use zexe_algebra::AffineCurve;
 use zexe_fft::cfg_chunks;
@@ -10,35 +10,75 @@ use std::io::Read;
 /// Used for reading 1 group element from a serialized buffer
 pub trait Deserializer {
     /// Reads 1 compressed or uncompressed element
-    fn read_element<G: AffineCurve>(&mut self, compression: UseCompression) -> Result<G>;
+    fn read_element<G: AffineCurve>(
+        &mut self,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<G>;
 
     /// Reads exact number of elements
-    fn read_elements_exact<G: AffineCurve>(&mut self, num: usize, compression: UseCompression) -> Result<Vec<G>> {
-        (0..num).map(|_| self.read_element(compression)).collect()
+    fn read_elements_exact<G: AffineCurve>(
+        &mut self,
+        num: usize,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<Vec<G>> {
+        (0..num)
+            .map(|_| self.read_element(compression, check_correctness))
+            .collect()
     }
 
     /// Reads 1 compressed or uncompressed element to a pre-allocated element
-    fn read_element_preallocated<G: AffineCurve>(&mut self, el: &mut G, compression: UseCompression) -> Result<()>;
+    fn read_element_preallocated<G: AffineCurve>(
+        &mut self,
+        el: &mut G,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<()>;
 }
 
 pub trait BatchDeserializer {
     /// Reads multiple elements from the buffer
-    fn read_batch<G: AffineCurve>(&self, compression: UseCompression) -> Result<Vec<G>>;
+    fn read_batch<G: AffineCurve>(
+        &self,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<Vec<G>>;
 
     /// Reads multiple elements from the buffer to a preallocated array of Group elements
-    fn read_batch_preallocated<G: AffineCurve>(&self, elements: &mut [G], compression: UseCompression) -> Result<()>;
+    fn read_batch_preallocated<G: AffineCurve>(
+        &self,
+        elements: &mut [G],
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<()>;
 }
 
 impl<R: Read> Deserializer for R {
-    fn read_element<G: AffineCurve>(&mut self, compression: UseCompression) -> Result<G> {
-        Ok(match compression {
+    fn read_element<G: AffineCurve>(
+        &mut self,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<G> {
+        let point = match compression {
             UseCompression::Yes => G::deserialize(self)?,
             UseCompression::No => G::deserialize_uncompressed(self)?,
-        })
+        };
+
+        if check_correctness == CheckForCorrectness::Yes && point.is_zero() {
+            return Err(Error::PointAtInfinity);
+        }
+
+        Ok(point)
     }
 
-    fn read_element_preallocated<G: AffineCurve>(&mut self, el: &mut G, compression: UseCompression) -> Result<()> {
-        *el = self.read_element(compression)?;
+    fn read_element_preallocated<G: AffineCurve>(
+        &mut self,
+        el: &mut G,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<()> {
+        *el = self.read_element(compression, check_correctness)?;
         Ok(())
     }
 }
@@ -46,12 +86,21 @@ impl<R: Read> Deserializer for R {
 // We implement this for slices so that the consumer does not need to write the `&mut slice.as_ref()`
 // boilerplate in each call. This should have no performance overhead
 impl Deserializer for [u8] {
-    fn read_element<G: AffineCurve>(&mut self, compression: UseCompression) -> Result<G> {
-        (&*self).read_element(compression)
+    fn read_element<G: AffineCurve>(
+        &mut self,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<G> {
+        (&*self).read_element(compression, check_correctness)
     }
 
-    fn read_element_preallocated<G: AffineCurve>(&mut self, el: &mut G, compression: UseCompression) -> Result<()> {
-        *el = self.read_element(compression)?;
+    fn read_element_preallocated<G: AffineCurve>(
+        &mut self,
+        el: &mut G,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<()> {
+        *el = self.read_element(compression, check_correctness)?;
         Ok(())
     }
 }
@@ -59,18 +108,27 @@ impl Deserializer for [u8] {
 // We implement this specifically for slices so that we can take advantage
 // of parallel iterators
 impl BatchDeserializer for [u8] {
-    fn read_batch<G: AffineCurve>(&self, compression: UseCompression) -> Result<Vec<G>> {
+    fn read_batch<G: AffineCurve>(
+        &self,
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<Vec<G>> {
         let size = buffer_size::<G>(compression);
         cfg_chunks!(&*self, size)
-            .map(|mut buf| buf.read_element(compression))
+            .map(|mut buf| buf.read_element(compression, check_correctness))
             .collect::<Result<Vec<_>>>()
     }
 
-    fn read_batch_preallocated<G: AffineCurve>(&self, elements: &mut [G], compression: UseCompression) -> Result<()> {
+    fn read_batch_preallocated<G: AffineCurve>(
+        &self,
+        elements: &mut [G],
+        compression: UseCompression,
+        check_correctness: CheckForCorrectness,
+    ) -> Result<()> {
         let size = buffer_size::<G>(compression);
         cfg_chunks!(&*self, size)
             .zip(elements)
-            .map(|(mut buf, el)| buf.read_element_preallocated(el, compression))
+            .map(|(mut buf, el)| buf.read_element_preallocated(el, compression, check_correctness))
             .collect::<Result<Vec<_>>>()?;
         Ok(())
     }

--- a/setup-utils/src/lib.rs
+++ b/setup-utils/src/lib.rs
@@ -12,7 +12,7 @@ mod groth16_utils;
 pub use groth16_utils::Groth16Params;
 
 mod elements;
-pub use elements::{ElementType, UseCompression};
+pub use elements::{CheckForCorrectness, ElementType, UseCompression};
 
 mod helpers;
 pub use helpers::*;


### PR DESCRIPTION
CheckForCorrectness checks whether an element is the infinity points when being read. This is important for verification, where pairings checks would silently pass instead of fail.