### PR TITLE
fix: ensure overlap between chunks

### DIFF
--- a/phase1/src/helpers/buffers.rs
+++ b/phase1/src/helpers/buffers.rs
@@ -24,12 +24,26 @@ pub(crate) fn iter_chunk(
     mut action: impl FnMut(usize, usize) -> Result<()>,
 ) -> Result<()> {
     (0..parameters.powers_g1_length)
-        .chunks(parameters.batch_size)
+        .chunks(parameters.batch_size - 1)
         .into_iter()
         .map(|chunk| {
             let (start, end) = match chunk.minmax() {
-                MinMaxResult::MinMax(start, end) => (start, end + 1),
-                MinMaxResult::OneElement(start) => (start, start + 1),
+                MinMaxResult::MinMax(start, end) => (
+                    start,
+                    if end >= parameters.powers_g1_length - 1 {
+                        end + 1
+                    } else {
+                        end + 2
+                    },
+                ), // ensure there's overlap between chunks
+                MinMaxResult::OneElement(start) => (
+                    start,
+                    if start >= parameters.powers_g1_length - 1 {
+                        start + 1
+                    } else {
+                        start + 2
+                    },
+                ),
                 _ => return Err(Error::InvalidChunk),
             };
             action(start, end)


### PR DESCRIPTION
Ratio verification between powers of tau previously only worked in the context of a chunk.
For example, if chunk 1 had (tau^2, tau^3, tau^4) and chunk 2 had (tau^10,tau^11,tau^12) - both chunks internally have the same ratio tau, but between the chunks the ratio is tau^6.

This PR ensures that the first element from the succeeding chunk is compared to the last element in the current chunk.