### PR TITLE
feat(coordinator): support different compression modes and adjust locators

### DIFF
--- a/phase1-cli/src/new_challenge.rs
+++ b/phase1-cli/src/new_challenge.rs
@@ -6,9 +6,11 @@ use zexe_algebra::PairingEngine as Engine;
 use memmap::*;
 use std::{fs::OpenOptions, io::Write};
 
-const COMPRESS_NEW_CHALLENGE: UseCompression = UseCompression::No;
-
-pub fn new_challenge<T: Engine + Sync>(challenge_filename: &str, parameters: &Phase1Parameters<T>) {
+pub fn new_challenge<T: Engine + Sync>(
+    compress_new_challenge: UseCompression,
+    challenge_filename: &str,
+    parameters: &Phase1Parameters<T>,
+) {
     println!(
         "Will generate an empty accumulator for 2^{} powers of tau",
         parameters.total_size_in_log2
@@ -22,7 +24,7 @@ pub fn new_challenge<T: Engine + Sync>(challenge_filename: &str, parameters: &Ph
         .open(challenge_filename)
         .expect("unable to create challenge file");
 
-    let expected_challenge_length = match COMPRESS_NEW_CHALLENGE {
+    let expected_challenge_length = match compress_new_challenge {
         UseCompression::Yes => parameters.contribution_size - parameters.public_key_size,
         UseCompression::No => parameters.accumulator_size,
     };
@@ -48,7 +50,7 @@ pub fn new_challenge<T: Engine + Sync>(challenge_filename: &str, parameters: &Ph
     println!("Blank hash for an empty challenge:");
     print_hash(&hash);
 
-    Phase1::initialization(&mut writable_map, COMPRESS_NEW_CHALLENGE, &parameters)
+    Phase1::initialization(&mut writable_map, compress_new_challenge, &parameters)
         .expect("generation of initial accumulator is successful");
     writable_map.flush().expect("unable to flush memmap to disk");
 

--- a/phase1-cli/src/transform_ratios.rs
+++ b/phase1-cli/src/transform_ratios.rs
@@ -8,7 +8,7 @@ use std::fs::OpenOptions;
 
 pub fn transform_ratios<T: Engine + Sync>(response_filename: &str, parameters: &Phase1Parameters<T>) {
     println!(
-        "Will verify and decompress a contribution to accumulator for 2^{} powers of tau",
+        "Will verify ratios in a contribution of accumulator for 2^{} powers of tau",
         parameters.total_size_in_log2
     );
 

--- a/phase1-coordinator/src/apis/chunk_get.rs
+++ b/phase1-coordinator/src/apis/chunk_get.rs
@@ -18,7 +18,7 @@ pub fn chunk_get(
     }
 
     // Return the next contribution locator for the given chunk ID.
-    match coordinator.next_contribution_locator(chunk_id) {
+    match coordinator.next_contribution_locator(chunk_id, false) {
         Ok(contribution_locator) => {
             let response = json!({
                 "status": "ok",

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -61,19 +61,28 @@ impl Verification {
             round_height, chunk_id, contribution_id
         );
 
+        let compressed_input = environment.compressed_inputs();
+        let compressed_output = environment.compressed_outputs();
+
         // Execute ceremony verification on chunk.
         let (_, _, curve, _, _, _) = settings.clone();
         let result = panic::catch_unwind(|| {
             match curve {
                 CurveKind::Bls12_377 => transform_pok_and_correctness(
+                    compressed_input,
                     &previous_locator,
+                    compressed_output,
                     &current_locator,
+                    compressed_input,
                     &next_locator,
                     &phase1_chunked_parameters!(Bls12_377, settings, chunk_id),
                 ),
                 CurveKind::BW6 => transform_pok_and_correctness(
+                    compressed_input,
                     &previous_locator,
+                    compressed_output,
                     &current_locator,
+                    compressed_input,
                     &next_locator,
                     &phase1_chunked_parameters!(BW6_761, settings, chunk_id),
                 ),

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -118,6 +118,7 @@ impl From<CoordinatorError> for anyhow::Error {
 }
 
 /// A core structure for operating the Phase 1 ceremony.
+#[derive(Clone)]
 pub struct Coordinator {
     storage: Arc<RwLock<Box<dyn Storage>>>,
     environment: Environment,
@@ -280,7 +281,7 @@ impl Coordinator {
     /// this function will return a `CoordinatorError`.
     ///
     #[inline]
-    pub fn current_contribution_locator(&self, chunk_id: u64) -> Result<String, CoordinatorError> {
+    pub fn current_contribution_locator(&self, chunk_id: u64, verified: bool) -> Result<String, CoordinatorError> {
         // Fetch the current round.
         let current_round = self.current_round()?;
         // Fetch the current round height.
@@ -292,10 +293,12 @@ impl Coordinator {
 
         // Check that the contribution locator corresponding to the current contribution ID
         // exists for the current round and given chunk ID.
-        if !self
-            .environment
-            .contribution_locator_exists(current_round_height, chunk_id, current_contribution_id)
-        {
+        if !self.environment.contribution_locator_exists(
+            current_round_height,
+            chunk_id,
+            current_contribution_id,
+            verified,
+        ) {
             return Err(CoordinatorError::ContributionLocatorMissing);
         }
 
@@ -307,7 +310,7 @@ impl Coordinator {
         // Fetch the current contribution locator.
         let current_contribution_locator =
             self.environment
-                .contribution_locator(current_round_height, chunk_id, current_contribution_id);
+                .contribution_locator(current_round_height, chunk_id, current_contribution_id, verified);
 
         Ok(current_contribution_locator)
     }
@@ -329,7 +332,7 @@ impl Coordinator {
     /// this function will return a `CoordinatorError`.
     ///
     #[inline]
-    pub fn next_contribution_locator(&self, chunk_id: u64) -> Result<String, CoordinatorError> {
+    pub fn next_contribution_locator(&self, chunk_id: u64, verified: bool) -> Result<String, CoordinatorError> {
         // Fetch the current round.
         let current_round = self.current_round()?;
         // Fetch the current round height.
@@ -350,7 +353,7 @@ impl Coordinator {
         // does NOT exist for the current round and given chunk ID.
         if self
             .environment
-            .contribution_locator_exists(current_round_height, chunk_id, next_contribution_id)
+            .contribution_locator_exists(current_round_height, chunk_id, next_contribution_id, verified)
         {
             return Err(CoordinatorError::ContributionLocatorAlreadyExists);
         }
@@ -358,7 +361,7 @@ impl Coordinator {
         // Fetch the next contribution locator.
         let next_contribution_locator =
             self.environment
-                .contribution_locator(current_round_height, chunk_id, next_contribution_id);
+                .contribution_locator(current_round_height, chunk_id, next_contribution_id, verified);
 
         Ok(next_contribution_locator)
     }
@@ -398,7 +401,7 @@ impl Coordinator {
                 // next contribution locator does NOT exist and
                 // that the current contribution locator exists
                 // and has already been verified.
-                self.next_contribution_locator(chunk_id)?
+                self.next_contribution_locator(chunk_id, false)?
             }
             Participant::Verifier(_) => {
                 // Check that the participant is an authorized verifier
@@ -409,14 +412,14 @@ impl Coordinator {
                 // This call enforces a strict check that the
                 // current contribution locator exist and
                 // has not been verified yet.
-                self.current_contribution_locator(chunk_id)?
+                self.current_contribution_locator(chunk_id, false)?
             }
         };
 
         // As a corollary, if the current contribution locator exists
         // and the current contribution has not been verified yet,
         // check that the given participant is not a contributor.
-        if self.current_contribution_locator(chunk_id).is_ok() && !current_contribution.is_verified() {
+        if self.current_contribution_locator(chunk_id, false).is_ok() && !current_contribution.is_verified() {
             // Check that the given participant is not a contributor.
             if participant.is_contributor() {
                 return Err(CoordinatorError::UnauthorizedChunkContributor);
@@ -554,7 +557,7 @@ impl Coordinator {
         // Check that the contribution locator corresponding to this round and chunk exists.
         if !self
             .environment
-            .contribution_locator_exists(current_round_height, chunk_id, current_contribution_id)
+            .contribution_locator_exists(current_round_height, chunk_id, current_contribution_id, false)
         {
             return Err(CoordinatorError::ContributionLocatorMissing);
         }
@@ -567,15 +570,18 @@ impl Coordinator {
         // Fetch the contribution locators for `Verification`.
         let (previous, current, next) = if chunk.only_contributions_complete(current_round.expected_num_contributions())
         {
-            let previous =
-                self.environment
-                    .contribution_locator(current_round_height, chunk_id, current_contribution_id - 1);
+            let previous = self.environment.contribution_locator(
+                current_round_height,
+                chunk_id,
+                current_contribution_id - 1,
+                true,
+            );
             let current =
                 self.environment
-                    .contribution_locator(current_round_height, chunk_id, current_contribution_id);
+                    .contribution_locator(current_round_height, chunk_id, current_contribution_id, false);
             let next = self
                 .environment
-                .contribution_locator(current_round_height + 1, chunk_id, 0);
+                .contribution_locator(current_round_height + 1, chunk_id, 0, true);
 
             // Initialize the chunk directory of the new round so the next locator file will be saved.
             self.environment
@@ -583,15 +589,18 @@ impl Coordinator {
 
             (previous, current, next)
         } else {
-            let previous =
-                self.environment
-                    .contribution_locator(current_round_height, chunk_id, current_contribution_id - 1);
+            let previous = self.environment.contribution_locator(
+                current_round_height,
+                chunk_id,
+                current_contribution_id - 1,
+                true,
+            );
             let current =
                 self.environment
-                    .contribution_locator(current_round_height, chunk_id, current_contribution_id);
+                    .contribution_locator(current_round_height, chunk_id, current_contribution_id, false);
             let next =
                 self.environment
-                    .contribution_locator(current_round_height, chunk_id, current_contribution_id + 1);
+                    .contribution_locator(current_round_height, chunk_id, current_contribution_id, true);
             (previous, current, next)
         };
 
@@ -758,7 +767,7 @@ impl Coordinator {
         // Fetch the next contribution locator.
         let next_contribution_locator =
             self.environment
-                .contribution_locator(current_round_height, chunk_id, next_contribution_id);
+                .contribution_locator(current_round_height, chunk_id, next_contribution_id, false);
 
         Ok(next_contribution_locator)
     }
@@ -834,14 +843,17 @@ impl Coordinator {
                 info!("Coordinator completed initialization on chunk {}", chunk_id);
 
                 // 1 - Check that the contribution locator corresponding to this round's chunk now exists.
-                if !self.environment.contribution_locator_exists(round_height, chunk_id, 0) {
+                if !self
+                    .environment
+                    .contribution_locator_exists(round_height, chunk_id, 0, true)
+                {
                     return Err(CoordinatorError::ContributionLocatorMissing);
                 }
 
                 // 2 - Check that the contribution locator corresponding to the next round's chunk now exists.
                 if !self
                     .environment
-                    .contribution_locator_exists(round_height + 1, chunk_id, 0)
+                    .contribution_locator_exists(round_height + 1, chunk_id, 0, true)
                 {
                     return Err(CoordinatorError::ContributionLocatorMissing);
                 }
@@ -874,7 +886,10 @@ impl Coordinator {
         // Check that each contribution transcript for the next round exists.
         for chunk_id in 0..self.environment.number_of_chunks() {
             debug!("Locating round {} chunk {} contribution 0", new_height, chunk_id);
-            if !self.environment.contribution_locator_exists(new_height, chunk_id, 0) {
+            if !self
+                .environment
+                .contribution_locator_exists(new_height, chunk_id, 0, true)
+            {
                 return Err(CoordinatorError::ContributionLocatorMissing);
             }
         }
@@ -922,7 +937,7 @@ impl Coordinator {
         // Check that the contribution locator corresponding to this round and chunk exists.
         if self
             .environment
-            .contribution_locator_exists(round_height, chunk_id, contribution_id)
+            .contribution_locator_exists(round_height, chunk_id, contribution_id, false)
         {
             error!("Locator for contribution {} already exists", contribution_id);
             return Err(CoordinatorError::ContributionLocatorAlreadyExists);
@@ -1341,7 +1356,6 @@ mod test {
     }
 
     fn coordinator_next_round_test() -> anyhow::Result<()> {
-        test_logger();
         clear_test_transcript();
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT_3.clone())?;

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -3,6 +3,7 @@ use crate::{
     storage::{ConcurrentMemory, InMemory, Storage},
 };
 use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
+use setup_utils::{CheckForCorrectness, UseCompression};
 
 use rocket_cors::{AllowedHeaders, AllowedOrigins, Cors};
 use url::Url;
@@ -175,11 +176,11 @@ impl Environment {
     /// By default, the coordinator returns `false` to minimize time
     /// spent by contributors on decompressing inputs.
     ///
-    pub const fn compressed_inputs(&self) -> bool {
+    pub const fn compressed_inputs(&self) -> UseCompression {
         match self {
-            Environment::Test(_) => false,
-            Environment::Development(_) => false,
-            Environment::Production(_) => false,
+            Environment::Test(_) => UseCompression::No,
+            Environment::Development(_) => UseCompression::No,
+            Environment::Production(_) => UseCompression::No,
         }
     }
 
@@ -189,11 +190,25 @@ impl Environment {
     /// By default, the coordinator returns `true` to minimize time
     /// spent by the coordinator and contributors on uploading chunks.
     ///
-    pub const fn compressed_outputs(&self) -> bool {
+    pub const fn compressed_outputs(&self) -> UseCompression {
         match self {
-            Environment::Test(_) => true,
-            Environment::Development(_) => true,
-            Environment::Production(_) => true,
+            Environment::Test(_) => UseCompression::Yes,
+            Environment::Development(_) => UseCompression::Yes,
+            Environment::Production(_) => UseCompression::Yes,
+        }
+    }
+
+    ///
+    /// Returns the input correctness check preference of the coordinator.
+    ///
+    /// By default, the coordinator returns `false` to minimize time
+    /// spent by the contributors on reading chunks.
+    ///
+    pub fn check_input_for_correctness(&self) -> CheckForCorrectness {
+        match self {
+            Environment::Test(_) => CheckForCorrectness::No,
+            Environment::Development(_) => CheckForCorrectness::No,
+            Environment::Production(_) => CheckForCorrectness::No,
         }
     }
 
@@ -294,8 +309,23 @@ impl Environment {
     }
 
     /// Returns the contribution locator for a given round, chunk ID, and contribution ID.
-    pub fn contribution_locator(&self, round_height: u64, chunk_id: u64, contribution_id: u64) -> String {
-        contribution_locator!(self, Local, Remote, Remote, round_height, chunk_id, contribution_id)
+    pub fn contribution_locator(
+        &self,
+        round_height: u64,
+        chunk_id: u64,
+        contribution_id: u64,
+        verified: bool,
+    ) -> String {
+        contribution_locator!(
+            self,
+            Local,
+            Remote,
+            Remote,
+            round_height,
+            chunk_id,
+            contribution_id,
+            verified
+        )
     }
 
     /// Initializes the contribution locator file for a given round, chunk ID, and contribution ID.
@@ -304,8 +334,23 @@ impl Environment {
     }
 
     /// Returns `true` if the contribution locator exists for a given round, chunk ID, and contribution ID.
-    pub fn contribution_locator_exists(&self, round_height: u64, chunk_id: u64, contribution_id: u64) -> bool {
-        contribution_locator_exists!(self, Local, Remote, Remote, round_height, chunk_id, contribution_id)
+    pub fn contribution_locator_exists(
+        &self,
+        round_height: u64,
+        chunk_id: u64,
+        contribution_id: u64,
+        verified: bool,
+    ) -> bool {
+        contribution_locator_exists!(
+            self,
+            Local,
+            Remote,
+            Remote,
+            round_height,
+            chunk_id,
+            contribution_id,
+            verified
+        )
     }
 
     /// Returns the round locator for a given round height.

--- a/phase1-coordinator/src/locators/local.rs
+++ b/phase1-coordinator/src/locators/local.rs
@@ -110,22 +110,29 @@ impl Locator for Local {
 
     /// Returns the contribution locator for a given round, chunk ID, and
     /// contribution ID from the coordinator.
-    fn contribution_locator(environment: &Environment, round_height: u64, chunk_id: u64, contribution_id: u64) -> String
+    fn contribution_locator(
+        environment: &Environment,
+        round_height: u64,
+        chunk_id: u64,
+        contribution_id: u64,
+        verified: bool,
+    ) -> String
     where
         Self: Sized,
     {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}`.
-        format!("{}/contribution_{}", path, contribution_id)
+        let verified_str = if verified { "_verified" } else { "" };
+        // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}{verified_str}`.
+        format!("{}/contribution_{}{}", path, contribution_id, verified_str)
     }
 
     /// Initializes the contribution locator file for a given round, chunk ID, and
     /// contribution ID from the coordinator.
     fn contribution_locator_init(environment: &Environment, round_height: u64, chunk_id: u64, contribution_id: u64) {
         // If the path does not exist, attempt to initialize the file path.
-        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id);
+        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id, false);
 
         let directory = Path::new(&path).parent().expect("unable to create parent directory");
         if !directory.exists() {
@@ -140,11 +147,12 @@ impl Locator for Local {
         round_height: u64,
         chunk_id: u64,
         contribution_id: u64,
+        verified: bool,
     ) -> bool
     where
         Self: Sized,
     {
-        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id);
+        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id, verified);
         Path::new(&path).exists()
     }
 

--- a/phase1-coordinator/src/locators/locator.rs
+++ b/phase1-coordinator/src/locators/locator.rs
@@ -50,6 +50,7 @@ pub trait Locator {
         round_height: u64,
         chunk_id: u64,
         contribution_id: u64,
+        verified: bool,
     ) -> String
     where
         Self: Sized;
@@ -67,6 +68,7 @@ pub trait Locator {
         round_height: u64,
         chunk_id: u64,
         contribution_id: u64,
+        verified: bool,
     ) -> bool
     where
         Self: Sized;

--- a/phase1-coordinator/src/locators/remote.rs
+++ b/phase1-coordinator/src/locators/remote.rs
@@ -76,15 +76,22 @@ impl Locator for Remote {
 
     /// Returns the contribution locator for a given round, chunk ID, and
     /// contribution ID from the coordinator.
-    fn contribution_locator(environment: &Environment, round_height: u64, chunk_id: u64, contribution_id: u64) -> String
+    fn contribution_locator(
+        environment: &Environment,
+        round_height: u64,
+        chunk_id: u64,
+        contribution_id: u64,
+        verified: bool,
+    ) -> String
     where
         Self: Sized,
     {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}`.
-        format!("{}/contribution/{}", path, contribution_id)
+        let verified_str = if verified { "_verified" } else { "" };
+        // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}{verified_str}`.
+        format!("{}/contribution/{}{}", path, contribution_id, verified_str)
     }
 
     /// Initializes the contribution locator file for a given round, chunk ID, and
@@ -105,11 +112,12 @@ impl Locator for Remote {
         round_height: u64,
         chunk_id: u64,
         contribution_id: u64,
+        verified: bool,
     ) -> bool
     where
         Self: Sized,
     {
-        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id);
+        let path = Self::contribution_locator(environment, round_height, chunk_id, contribution_id, verified);
         Path::new(&path).exists()
     }
 

--- a/phase1-coordinator/src/macros.rs
+++ b/phase1-coordinator/src/macros.rs
@@ -34,14 +34,13 @@ macro_rules! phase1_full_parameters {
 /// this is the initialization round.
 #[macro_export]
 macro_rules! contribution_filesize {
-    ($curve:ident, $settings:ident, $chunk_id:ident, $compressed:ident, $init:ident) => {{
+    ($curve:ident, $settings:ident, $chunk_id:ident, $compressed:ident) => {{
         use setup_utils::UseCompression;
 
         let parameters = phase1_chunked_parameters!($curve, $settings, $chunk_id);
-        match ($compressed, $init) {
-            (UseCompression::Yes, true) => (parameters.contribution_size - parameters.public_key_size) as u64,
-            (UseCompression::Yes, false) => parameters.contribution_size as u64,
-            (UseCompression::No, _) => parameters.accumulator_size as u64,
+        match $compressed {
+            UseCompression::Yes => parameters.contribution_size as u64,
+            UseCompression::No => (parameters.accumulator_size + parameters.public_key_size) as u64,
         }
     }};
 }
@@ -228,13 +227,17 @@ macro_rules! chunk_directory_exists {
 /// on the environment the coordinator is operating in.
 #[macro_export]
 macro_rules! contribution_locator {
-    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $chunk_id:ident, $cont_id:ident) => {{
+    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $chunk_id:ident, $cont_id:ident, $verified:ident) => {{
         use crate::locators::*;
 
         match $env {
-            Environment::Test(_) => $l1::contribution_locator($env, $round_height, $chunk_id, $cont_id),
-            Environment::Development(_) => $l2::contribution_locator($env, $round_height, $chunk_id, $cont_id),
-            Environment::Production(_) => $l3::contribution_locator($env, $round_height, $chunk_id, $cont_id),
+            Environment::Test(_) => $l1::contribution_locator($env, $round_height, $chunk_id, $cont_id, $verified),
+            Environment::Development(_) => {
+                $l2::contribution_locator($env, $round_height, $chunk_id, $cont_id, $verified)
+            }
+            Environment::Production(_) => {
+                $l3::contribution_locator($env, $round_height, $chunk_id, $cont_id, $verified)
+            }
         }
     }};
 }
@@ -258,13 +261,19 @@ macro_rules! contribution_locator_init {
 /// on the environment the coordinator is operating in.
 #[macro_export]
 macro_rules! contribution_locator_exists {
-    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $chunk_id:ident, $cont_id:ident) => {{
+    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $chunk_id:ident, $cont_id:ident, $verified:ident) => {{
         use crate::locators::*;
 
         match $env {
-            Environment::Test(_) => $l1::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id),
-            Environment::Development(_) => $l2::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id),
-            Environment::Production(_) => $l3::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id),
+            Environment::Test(_) => {
+                $l1::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id, $verified)
+            }
+            Environment::Development(_) => {
+                $l2::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id, $verified)
+            }
+            Environment::Production(_) => {
+                $l3::contribution_locator_exists($env, $round_height, $chunk_id, $cont_id, $verified)
+            }
         }
     }};
 }

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -91,7 +91,7 @@ impl Round {
                 Chunk::new(
                     chunk_id as u64,
                     verifier.clone(),
-                    environment.contribution_locator(round_height, chunk_id as u64, 0),
+                    environment.contribution_locator(round_height, chunk_id as u64, 0, true),
                 )
                 .expect("failed to create chunk")
             })

--- a/phase1-coordinator/src/testing/resources/round.json
+++ b/phase1-coordinator/src/testing/resources/round.json
@@ -19,7 +19,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -32,7 +32,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -45,7 +45,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -58,7 +58,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -71,7 +71,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -84,7 +84,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -97,7 +97,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0_verified",
                     "verified": true
                 }
             ]
@@ -110,7 +110,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0_verified",
                     "verified": true
                 }
             ]

--- a/phase1-coordinator/src/testing/resources/round_partial.json
+++ b/phase1-coordinator/src/testing/resources/round_partial.json
@@ -16,7 +16,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -36,7 +36,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -56,7 +56,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -76,7 +76,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -96,7 +96,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -116,7 +116,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -136,7 +136,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -156,7 +156,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -176,7 +176,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/8/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/8/contribution/0_verified",
                     "verified": true
                 },
                 {
@@ -196,7 +196,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/9/contribution/0",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/9/contribution/0_verified",
                     "verified": true
                 },
                 {

--- a/phase1-coordinator/src/testing/resources/test_round_0.json
+++ b/phase1-coordinator/src/testing/resources/test_round_0.json
@@ -17,7 +17,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_0/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_0/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -30,7 +30,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_1/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_1/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -43,7 +43,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_2/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_2/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -56,7 +56,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_3/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_3/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -69,7 +69,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_4/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_4/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -82,7 +82,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_5/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_5/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -95,7 +95,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_6/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_6/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -108,7 +108,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_7/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_7/contribution_0_verified",
                     "verified": true
                 }
             ]

--- a/phase1-coordinator/src/testing/resources/test_round_1_initial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_initial.json
@@ -19,7 +19,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_0/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_0/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -32,7 +32,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_1/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_1/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -45,7 +45,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_2/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_2/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -58,7 +58,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_3/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_3/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -71,7 +71,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_4/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_4/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -84,7 +84,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_5/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_5/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -97,7 +97,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_6/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_6/contribution_0_verified",
                     "verified": true
                 }
             ]
@@ -110,7 +110,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_7/contribution_0",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_7/contribution_0_verified",
                     "verified": true
                 }
             ]


### PR DESCRIPTION
This PR introduces flexible and centralized support for compression modes in contributions and response, which are now controlled by the coordinator environment.

Additionally, it modifies contribution locators to include a "verified" status, to signify whether they're a challenge or a response. In a world where compression modes differ between inputs and outputs, one will contain a compressed version and the other an uncompressed one. If they're equal, they're mostly the same. In any case, the challenges do not contain the public key of the response.
