### PR TITLE
Removes 'verified' from `next_contribution_locator` as it must always be false.

### DIFF
--- a/phase1-coordinator/src/apis/chunk_get.rs
+++ b/phase1-coordinator/src/apis/chunk_get.rs
@@ -18,7 +18,7 @@ pub fn chunk_get(
     }
 
     // Return the next contribution locator for the given chunk ID.
-    match coordinator.next_contribution_locator(chunk_id, false) {
+    match coordinator.next_contribution_locator(chunk_id) {
         Ok(contribution_locator) => {
             let response = json!({
                 "status": "ok",

--- a/phase1-coordinator/src/commands/aggregation.rs
+++ b/phase1-coordinator/src/commands/aggregation.rs
@@ -7,11 +7,11 @@ use std::fs::OpenOptions;
 use tracing::{debug, error, trace};
 use zexe_algebra::{Bls12_377, BW6_761};
 
-pub struct Aggregation;
+pub(crate) struct Aggregation;
 
 impl Aggregation {
     /// Runs aggregation for a given environment and round.
-    pub fn run(environment: &Environment, round: &Round) -> anyhow::Result<()> {
+    pub(crate) fn run(environment: &Environment, round: &Round) -> anyhow::Result<()> {
         // Fetch the round height.
         let round_height = round.round_height();
 
@@ -67,16 +67,16 @@ impl Aggregation {
         // Fetch the round height.
         let round_height = round.round_height();
 
-        // Fetch the contribution ID.
+        // Fetch the compressed output setting.
         let compressed = environment.compressed_outputs();
 
+        // Create a variable to save the contribution ID of the previous iteration.
         let mut previous_chunk_contribution_id = 0;
 
         for chunk_id in 0..environment.number_of_chunks() {
             trace!("Loading contribution from chunk {}", chunk_id);
 
-            // When aggregating, the verified contribution ID will always be 0, since they'll be
-            // the first files in the next round.
+            // Fetch the contribution ID.
             let contribution_id = round.get_chunk(chunk_id)?.current_contribution_id();
 
             // Sanity check that each contribution ID is the same,

--- a/phase1-coordinator/src/commands/computation.rs
+++ b/phase1-coordinator/src/commands/computation.rs
@@ -7,7 +7,7 @@ use std::{panic, time::Instant};
 use tracing::{info, trace};
 use zexe_algebra::{Bls12_377, BW6_761};
 
-pub struct Computation;
+pub(crate) struct Computation;
 
 impl Computation {
     ///
@@ -15,7 +15,7 @@ impl Computation {
     ///
     /// Executes the round computation on a given chunk ID and contribution ID using phase1-cli logic.
     ///
-    pub fn run(
+    pub(crate) fn run(
         environment: &Environment,
         round_height: u64,
         chunk_id: u64,

--- a/phase1-coordinator/src/commands/initialization.rs
+++ b/phase1-coordinator/src/commands/initialization.rs
@@ -8,7 +8,7 @@ use std::{fs, fs::OpenOptions, panic, time::Instant};
 use tracing::{debug, info, trace};
 use zexe_algebra::{Bls12_377, BW6_761};
 
-pub struct Initialization;
+pub(crate) struct Initialization;
 
 impl Initialization {
     ///
@@ -16,7 +16,7 @@ impl Initialization {
     ///
     /// Executes the round initialization on a given chunk ID using phase1-cli logic.
     ///
-    pub fn run(environment: &Environment, round_height: u64, chunk_id: u64) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn run(environment: &Environment, round_height: u64, chunk_id: u64) -> anyhow::Result<Vec<u8>> {
         info!("Starting initialization and migration on chunk {}", chunk_id);
         let now = Instant::now();
 

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -6,7 +6,7 @@ use std::panic;
 use tracing::info;
 use zexe_algebra::{Bls12_377, BW6_761};
 
-pub struct Verification;
+pub(crate) struct Verification;
 
 impl Verification {
     ///
@@ -14,7 +14,7 @@ impl Verification {
     ///
     /// Executes the round verification on a given chunk ID using phase1-cli logic.
     ///
-    pub fn run(
+    pub(crate) fn run(
         environment: &Environment,
         round_height: u64,
         chunk_id: u64,

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -332,7 +332,7 @@ impl Coordinator {
     /// this function will return a `CoordinatorError`.
     ///
     #[inline]
-    pub fn next_contribution_locator(&self, chunk_id: u64, verified: bool) -> Result<String, CoordinatorError> {
+    pub fn next_contribution_locator(&self, chunk_id: u64) -> Result<String, CoordinatorError> {
         // Fetch the current round.
         let current_round = self.current_round()?;
         // Fetch the current round height.
@@ -353,7 +353,7 @@ impl Coordinator {
         // does NOT exist for the current round and given chunk ID.
         if self
             .environment
-            .contribution_locator_exists(current_round_height, chunk_id, next_contribution_id, verified)
+            .contribution_locator_exists(current_round_height, chunk_id, next_contribution_id, false)
         {
             return Err(CoordinatorError::ContributionLocatorAlreadyExists);
         }
@@ -361,7 +361,7 @@ impl Coordinator {
         // Fetch the next contribution locator.
         let next_contribution_locator =
             self.environment
-                .contribution_locator(current_round_height, chunk_id, next_contribution_id, verified);
+                .contribution_locator(current_round_height, chunk_id, next_contribution_id, false);
 
         Ok(next_contribution_locator)
     }
@@ -401,7 +401,7 @@ impl Coordinator {
                 // next contribution locator does NOT exist and
                 // that the current contribution locator exists
                 // and has already been verified.
-                self.next_contribution_locator(chunk_id, false)?
+                self.next_contribution_locator(chunk_id)?
             }
             Participant::Verifier(_) => {
                 // Check that the participant is an authorized verifier
@@ -456,7 +456,7 @@ impl Coordinator {
     ///
     #[inline]
     pub fn add_contribution(&self, chunk_id: u64, participant: Participant) -> Result<String, CoordinatorError> {
-        info!("Attempting to add contribution to a chunk");
+        info!("Attempting to add a contribution to chunk {}", chunk_id);
 
         // Check that the participant is a contributor.
         if !participant.is_contributor() {
@@ -1275,7 +1275,6 @@ mod test {
 
     // TODO (howardwu): Update and finish this test to reflect new compressed output setting.
     fn coordinator_aggregation_test() -> anyhow::Result<()> {
-        test_logger();
         clear_test_transcript();
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT_3.clone())?;


### PR DESCRIPTION
A strict precondition of `next_contribution_locator` is that the locator corresponding to the given round height, chunk ID, and contribution ID must not exist or be verified. To adhere to intended usage, this PR removes `verified` as an input argument to the method.