### PR TITLE
Update local and remote contribution locators to use `verified`  and `unverified` as file extensions

### DIFF
--- a/phase1-coordinator/src/locators/local.rs
+++ b/phase1-coordinator/src/locators/local.rs
@@ -123,7 +123,9 @@ impl Locator for Local {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        match verified {
+        // As the contribution at ID 0 is a continuation of the last contribution
+        // in the previous round, it will always be verified by default.
+        match verified || contribution_id == 0 {
             // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}.verified`.
             true => format!("{}/contribution_{}.verified", path, contribution_id),
             // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}.unverified`.

--- a/phase1-coordinator/src/locators/local.rs
+++ b/phase1-coordinator/src/locators/local.rs
@@ -123,9 +123,12 @@ impl Locator for Local {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        let verified_str = if verified { "_verified" } else { "" };
-        // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}{verified_str}`.
-        format!("{}/contribution_{}{}", path, contribution_id, verified_str)
+        match verified {
+            // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}.verified`.
+            true => format!("{}/contribution_{}.verified", path, contribution_id),
+            // Set the contribution locator as `{chunk_directory}/contribution_{contribution_id}.unverified`.
+            false => format!("{}/contribution_{}.unverified", path, contribution_id),
+        }
     }
 
     /// Initializes the contribution locator file for a given round, chunk ID, and

--- a/phase1-coordinator/src/locators/remote.rs
+++ b/phase1-coordinator/src/locators/remote.rs
@@ -89,9 +89,12 @@ impl Locator for Remote {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        let verified_str = if verified { "_verified" } else { "" };
-        // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}{verified_str}`.
-        format!("{}/contribution/{}{}", path, contribution_id, verified_str)
+        match verified {
+            // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}.verified`.
+            true => format!("{}/contribution/{}.verified", path, contribution_id),
+            // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}.unverified`.
+            false => format!("{}/contribution/{}.unverified", path, contribution_id),
+        }
     }
 
     /// Initializes the contribution locator file for a given round, chunk ID, and

--- a/phase1-coordinator/src/locators/remote.rs
+++ b/phase1-coordinator/src/locators/remote.rs
@@ -89,7 +89,9 @@ impl Locator for Remote {
         // Fetch the chunk directory path.
         let path = Self::chunk_directory(environment, round_height, chunk_id);
 
-        match verified {
+        // As the contribution at ID 0 is a continuation of the last contribution
+        // in the previous round, it will always be verified by default.
+        match verified || contribution_id == 0 {
             // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}.verified`.
             true => format!("{}/contribution/{}.verified", path, contribution_id),
             // Set the contribution locator as `{chunk_directory}/contribution/{contribution_id}.unverified`.

--- a/phase1-coordinator/src/testing/resources/round.json
+++ b/phase1-coordinator/src/testing/resources/round.json
@@ -19,7 +19,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -32,7 +32,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -45,7 +45,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -58,7 +58,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -71,7 +71,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -84,7 +84,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -97,7 +97,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0.verified",
                     "verified": true
                 }
             ]
@@ -110,7 +110,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0.verified",
                     "verified": true
                 }
             ]

--- a/phase1-coordinator/src/testing/resources/round_partial.json
+++ b/phase1-coordinator/src/testing/resources/round_partial.json
@@ -16,12 +16,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/0/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/0/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/0/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -36,12 +36,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/1/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/1/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/1/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -56,12 +56,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/2/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/2/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/2/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -76,12 +76,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/3/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/3/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/3/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -96,12 +96,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/4/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/4/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/4/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -116,12 +116,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/5/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/5/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/5/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -136,12 +136,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/6/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/6/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/6/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -156,12 +156,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/7/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/7/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/7/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -176,12 +176,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/8/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/8/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/8/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/8/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false
@@ -196,12 +196,12 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "0xEC60b9a43529c12CA83Af466D8A6F8444392D47C",
-                    "verifiedLocation": "http://167.71.156.62:8080/chunks/9/contribution/0_verified",
+                    "verifiedLocation": "http://167.71.156.62:8080/chunks/9/contribution/0.verified",
                     "verified": true
                 },
                 {
                     "contributorId": "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",
-                    "contributedLocation": "http://167.71.156.62:8080/chunks/9/contribution/1",
+                    "contributedLocation": "http://167.71.156.62:8080/chunks/9/contribution/1.unverified",
                     "verifierId": null,
                     "verifiedLocation": null,
                     "verified": false

--- a/phase1-coordinator/src/testing/resources/test_round_0.json
+++ b/phase1-coordinator/src/testing/resources/test_round_0.json
@@ -17,7 +17,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_0/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_0/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -30,7 +30,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_1/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_1/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -43,7 +43,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_2/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_2/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -56,7 +56,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_3/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_3/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -69,7 +69,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_4/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_4/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -82,7 +82,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_5/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_5/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -95,7 +95,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_6/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_6/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -108,7 +108,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_0/chunk_7/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_0/chunk_7/contribution_0.verified",
                     "verified": true
                 }
             ]

--- a/phase1-coordinator/src/testing/resources/test_round_1_initial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_initial.json
@@ -19,7 +19,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_0/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_0/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -32,7 +32,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_1/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_1/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -45,7 +45,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_2/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_2/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -58,7 +58,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_3/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_3/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -71,7 +71,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_4/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_4/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -84,7 +84,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_5/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_5/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -97,7 +97,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_6/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_6/contribution_0.verified",
                     "verified": true
                 }
             ]
@@ -110,7 +110,7 @@
                     "contributorId": null,
                     "contributedLocation": null,
                     "verifierId": "test-coordinator-verifier",
-                    "verifiedLocation": "./transcript/test/round_1/chunk_7/contribution_0_verified",
+                    "verifiedLocation": "./transcript/test/round_1/chunk_7/contribution_0.verified",
                     "verified": true
                 }
             ]


### PR DESCRIPTION
Update local and remote contribution locators to use `verified`  and `unverified` as file extensions.