### PR TITLE
feat(coordinator): adds reset round and timeout functionalities

### DIFF
--- a/phase1-coordinator/src/commands/aggregation.rs
+++ b/phase1-coordinator/src/commands/aggregation.rs
@@ -36,7 +36,7 @@ impl Aggregation {
         // Execute aggregation on given round.
         let chunk_id = 0usize;
         let settings = environment.to_settings();
-        let (_, _, curve, _, _, _) = settings;
+        let (_, _, curve, _, _, _, _, _) = settings;
         let result = match curve {
             CurveKind::Bls12_377 => Phase1::aggregation(
                 &contribution_readers,
@@ -100,7 +100,7 @@ impl Aggregation {
 
             // Derive the expected file size of the contribution.
             let settings = environment.to_settings();
-            let (_, _, curve, _, _, _) = settings;
+            let (_, _, curve, _, _, _, _, _) = settings;
             let expected = match curve {
                 CurveKind::Bls12_377 => contribution_filesize!(Bls12_377, settings, chunk_id, compressed),
                 CurveKind::BW6 => contribution_filesize!(BW6_761, settings, chunk_id, compressed),
@@ -153,7 +153,7 @@ impl Aggregation {
 
         // Check the round filesize will fit on the system.
         let settings = environment.to_settings();
-        let (_, _, curve, _, _, _) = settings;
+        let (_, _, curve, _, _, _, _, _) = settings;
         let round_size = match curve {
             CurveKind::Bls12_377 => round_filesize!(Bls12_377, settings, chunk_id, compressed, is_initial),
             CurveKind::BW6 => round_filesize!(BW6_761, settings, chunk_id, compressed, is_initial),

--- a/phase1-coordinator/src/commands/computation.rs
+++ b/phase1-coordinator/src/commands/computation.rs
@@ -45,7 +45,7 @@ impl Computation {
         let check_input_for_correctness = environment.check_input_for_correctness();
         // Execute computation on chunk.
         let result = panic::catch_unwind(|| {
-            let (_, _, curve, _, _, _) = settings;
+            let (_, _, curve, _, _, _, _, _) = settings;
             match curve {
                 CurveKind::Bls12_377 => contribute(
                     compressed_input,

--- a/phase1-coordinator/src/commands/initialization.rs
+++ b/phase1-coordinator/src/commands/initialization.rs
@@ -36,7 +36,7 @@ impl Initialization {
         let compressed_input = environment.compressed_inputs();
         // Execute ceremony initialization on chunk.
         let result = panic::catch_unwind(|| {
-            let (_, _, curve, _, _, _) = settings;
+            let (_, _, curve, _, _, _, _, _) = settings;
             match curve {
                 CurveKind::Bls12_377 => new_challenge(
                     compressed_input,

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -65,7 +65,7 @@ impl Verification {
         let compressed_output = environment.compressed_outputs();
 
         // Execute ceremony verification on chunk.
-        let (_, _, curve, _, _, _) = settings.clone();
+        let (_, _, curve, _, _, _, _, _) = settings.clone();
         let result = panic::catch_unwind(|| {
             match curve {
                 CurveKind::Bls12_377 => transform_pok_and_correctness(

--- a/phase1-coordinator/src/locators/locator.rs
+++ b/phase1-coordinator/src/locators/locator.rs
@@ -6,6 +6,11 @@ pub trait Locator {
     where
         Self: Sized;
 
+    /// Returns the round backup directory for a given round height and tag from the coordinator.
+    fn round_backup_directory(environment: &Environment, round_height: u64, tag: &str) -> String
+    where
+        Self: Sized;
+
     /// Initializes the round directory for a given environment and round height.
     fn round_directory_init(environment: &Environment, round_height: u64)
     where
@@ -19,6 +24,11 @@ pub trait Locator {
 
     /// Resets the round directory for a given environment and round height.
     fn round_directory_reset(environment: &Environment, round_height: u64)
+    where
+        Self: Sized;
+
+    /// Resets and backups the round directory for a given environment and round height.
+    fn round_directory_reset_and_backup(environment: &Environment, round_height: u64, tag: &str)
     where
         Self: Sized;
 

--- a/phase1-coordinator/src/locators/remote.rs
+++ b/phase1-coordinator/src/locators/remote.rs
@@ -19,6 +19,14 @@ impl Locator for Remote {
         }
     }
 
+    /// Returns the round backup directory for a given round height and tag from the coordinator.
+    fn round_backup_directory(environment: &Environment, round_height: u64, tag: &str) -> String
+    where
+        Self: Sized,
+    {
+        format!("{}/backup/{}", Self::round_directory(environment, round_height), tag)
+    }
+
     /// Initializes the round directory for a given environment and round height.
     fn round_directory_init(_environment: &Environment, _round_height: u64)
     where
@@ -39,6 +47,11 @@ impl Locator for Remote {
 
     /// Resets the round directory for a given environment and round height.
     fn round_directory_reset(_environment: &Environment, _round_height: u64) {
+        unimplemented!()
+    }
+
+    /// Resets and backups the round directory for a given environment and round height.
+    fn round_directory_reset_and_backup(_environment: &Environment, _round_height: u64, _tag: &str) {
         unimplemented!()
     }
 

--- a/phase1-coordinator/src/macros.rs
+++ b/phase1-coordinator/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! phase1_chunked_parameters {
     ($curve:ident, $settings:ident, $chunk_id:ident) => {{
         use phase1::Phase1Parameters;
 
-        let (contribution_mode, proving_system, _, power, batch_size, chunk_size) = $settings;
+        let (contribution_mode, proving_system, _, power, batch_size, chunk_size, _, _) = $settings;
         Phase1Parameters::<$curve>::new_chunk(
             contribution_mode,
             $chunk_id as usize,
@@ -24,7 +24,7 @@ macro_rules! phase1_full_parameters {
     ($curve:ident, $settings:ident) => {{
         use phase1::Phase1Parameters;
 
-        let (_, proving_system, _, power, batch_size, _) = $settings;
+        let (_, proving_system, _, power, batch_size, _, _, _) = $settings;
         Phase1Parameters::<$curve>::new_full(proving_system, power, batch_size)
     }};
 }
@@ -118,6 +118,21 @@ macro_rules! round_directory {
     }};
 }
 
+/// Returns the round backup directory using a locator that is determined based
+/// on the environment the coordinator is operating in and the tag.
+#[macro_export]
+macro_rules! round_backup_directory {
+    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $tag:ident) => {{
+        use crate::locators::*;
+
+        match $env {
+            Environment::Test(_) => $l1::round_backup_directory($env, $round_height, $tag),
+            Environment::Development(_) => $l2::round_backup_directory($env, $round_height, $tag),
+            Environment::Production(_) => $l3::round_backup_directory($env, $round_height, $tag),
+        }
+    }};
+}
+
 /// Initializes the round directory for a given round height using a locator that is
 /// determined based on the environment the coordinator is operating in.
 #[macro_export]
@@ -159,6 +174,21 @@ macro_rules! round_directory_reset {
             Environment::Test(_) => $l1::round_directory_reset($env, $round_height),
             Environment::Development(_) => $l2::round_directory_reset($env, $round_height),
             Environment::Production(_) => $l3::round_directory_reset($env, $round_height),
+        }
+    }};
+}
+
+/// Resets and backup the round directory for a given round height if permitted using a locator
+/// that is determined based on the environment the coordinator is operating in and the tag.
+#[macro_export]
+macro_rules! round_directory_reset_and_backup {
+    ($env:ident, $l1:ident, $l2:ident, $l3:ident, $round_height:ident, $tag:ident) => {{
+        use crate::locators::*;
+
+        match $env {
+            Environment::Test(_) => $l1::round_directory_reset_and_backup($env, $round_height, $tag),
+            Environment::Development(_) => $l2::round_directory_reset_and_backup($env, $round_height, $tag),
+            Environment::Production(_) => $l3::round_directory_reset_and_backup($env, $round_height, $tag),
         }
     }};
 }

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -122,6 +122,12 @@ impl Round {
         self.height
     }
 
+    /// Returns the time the round started at.
+    #[inline]
+    pub fn started_at(&self) -> &Option<DateTime<Utc>> {
+        &self.started_at
+    }
+
     /// Returns the number of contributors authorized for this round.
     #[inline]
     pub fn number_of_contributors(&self) -> u64 {

--- a/phase1-coordinator/src/storage/concurrent_memory.rs
+++ b/phase1-coordinator/src/storage/concurrent_memory.rs
@@ -55,6 +55,14 @@ impl Storage for ConcurrentMemory {
         true
     }
 
+    /// Stores an instance of `ConcurrentMemory` for backup, in case of failure.
+    /// If successful, returns `true`. Otherwise, returns `false`.
+    #[inline]
+    fn save_backup(&mut self, _tag: &str) -> bool {
+        // As this storage is in memory, we can always return `true`.
+        true
+    }
+
     /// Returns the value reference for a given key from storage, if it exists.
     #[inline]
     fn get(&self, key: &Key) -> Option<Value> {

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -75,6 +75,14 @@ impl Storage for Disk {
         true
     }
 
+    /// Stores an instance of `Disk`.
+    /// If successful, returns `true`. Otherwise, returns `false`.
+    #[inline]
+    fn save_backup(&mut self, _tag: &str) -> bool {
+        // TODO (howardwu): Fix storage key and value serialization before proceeding.
+        true
+    }
+
     /// Returns the value reference for a given key from storage, if it exists.
     #[inline]
     fn get(&self, key: &Key) -> Option<Value> {

--- a/phase1-coordinator/src/storage/in_memory.rs
+++ b/phase1-coordinator/src/storage/in_memory.rs
@@ -29,6 +29,14 @@ impl Storage for InMemory {
         true
     }
 
+    /// Stores an instance of `InMemory` for backup, in case of failure.
+    /// If successful, returns `true`. Otherwise, returns `false`.
+    #[inline]
+    fn save_backup(&mut self, _tag: &str) -> bool {
+        // As this storage is in memory, we can always return `true`.
+        true
+    }
+
     /// Returns the value reference for a given key from storage, if it exists.
     #[inline]
     fn get(&self, key: &Key) -> Option<Value> {

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -29,6 +29,10 @@ pub trait Storage: Send + Sync {
     /// If successful, returns `true`. Otherwise, returns `false`.
     fn save(&mut self) -> bool;
 
+    /// Stores an instance of `Storage` for backup, in case of failure.
+    /// If successful, returns `true`. Otherwise, returns `false`.
+    fn save_backup(&mut self, tag: &str) -> bool;
+
     /// Returns the value for a given key from storage, if it exists.
     fn get(&self, key: &Key) -> Option<Value>;
 


### PR DESCRIPTION
This PR adds the ability to reset a round and support for lock and round timeouts.

Resetting a round through the `reset_round` method performs:
* A backup of the current round data and contributions.
* Deletion of the faulty round data and re-initialization of the round.

Additionally, we add two types of timeouts to the configuration: `LockTimeout` and `RoundTimeout` and a method `reset_if_timed_out` that checks whether a participant is locking a chunk for too long or a round has been running for too long. If so, it resets the round.

TODOs:
- [x] Call reset round when failing aggregation.
- [ ] When verification logic is integrated, if it fails, call reset round.
- [ ] Run the loop with `reset_if_timed_out` somewhere.
