### PR TITLE
Fix for the test with drop of multiple contributors

### DIFF
--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1897,7 +1897,7 @@ impl CoordinatorState {
             // Initialize sets for disposed tasks.
             let mut all_disposed_tasks: HashSet<Task> = participant_info.completed_tasks.iter().cloned().collect();
 
-            // A hashmap where the key is chunk id and the value is the the contribution id
+            // A HashMap of tasks represented as (chunk ID, contribution ID) pairs.
             let tasks_by_chunk: HashMap<u64, u64> = tasks.iter().map(|task| task.to_tuple()).collect();
 
             // For every contributor we check if there are affected tasks. If the task

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -16,6 +16,7 @@ use serde::{
 };
 use std::{
     collections::{HashMap, HashSet, LinkedList},
+    iter::FromIterator,
     str::FromStr,
 };
 use tracing::*;
@@ -1892,43 +1893,65 @@ impl CoordinatorState {
                 .clone()
                 .ok_or(CoordinatorError::CoordinatorStateNotInitialized)?
                 .number_of_contributors;
-            let dropped_bucket_id = participant_info.bucket_id;
 
-            // Initialize sets for disposing and disposed tasks.
-            let mut disposing_tasks: HashSet<Task> = participant_info.pending_tasks.iter().cloned().collect();
-            let mut disposed_tasks: HashSet<Task> = participant_info.completed_tasks.iter().cloned().collect();
+            // Initialize sets for disposed tasks.
+            let mut all_disposed_tasks: HashSet<Task> = participant_info.completed_tasks.iter().cloned().collect();
 
-            // All contributors with a bucket ID below the bucket ID of the dropped participant
-            // must recompute their contributions.
+            // A hashmap where the key is chunk id and the value is the the contribution id
+            let tasks_by_chunk: HashMap<u64, u64> = tasks.iter().map(|task| task.to_tuple()).collect();
+
+            // For every contributor we check if there are affected tasks. If the task
+            // is affected, it will be dropped and reassigned
             for contributor_info in self.current_contributors.values_mut() {
-                // Check if the current contributor has a lower bucket ID.
-                if contributor_info.bucket_id < dropped_bucket_id {
-                    warn!("Resetting tasks for contributor {}", contributor_info.id);
+                // If the pending task is in the same chunk with the dropped task
+                // then it should be recomputed
+                let (disposing_tasks, pending_tasks) = contributor_info
+                    .pending_tasks
+                    .iter()
+                    .cloned()
+                    .partition(|task| tasks_by_chunk.get(&task.chunk_id).is_some());
 
-                    // Move the pending tasks to the disposing tasks.
-                    contributor_info.disposing_tasks = contributor_info.pending_tasks.clone();
-                    contributor_info.pending_tasks = LinkedList::new();
+                contributor_info.disposing_tasks = disposing_tasks;
+                contributor_info.pending_tasks = pending_tasks;
 
-                    // Add the disposing tasks to the cumulative disposing tasks.
-                    disposing_tasks.extend(contributor_info.disposing_tasks.iter());
+                // If assigned task is based on the dropped task, it should also be dropped
+                let (disposed_tasks, assigned_tasks) =
+                    contributor_info.assigned_tasks.iter().cloned().partition(|task| {
+                        if let Some(contribution_id) = tasks_by_chunk.get(&task.chunk_id) {
+                            *contribution_id < task.contribution_id
+                        } else {
+                            false
+                        }
+                    });
+                contributor_info.assigned_tasks = assigned_tasks;
+                contributor_info.disposed_tasks = disposed_tasks;
 
-                    // Move the completed tasks to the disposed tasks.
-                    contributor_info.disposed_tasks = contributor_info.assigned_tasks.clone();
-                    contributor_info
-                        .disposed_tasks
-                        .extend(contributor_info.completed_tasks.iter());
-                    contributor_info.assigned_tasks = LinkedList::new();
-                    contributor_info.completed_tasks = LinkedList::new();
+                // If completed task is based on the dropped task, it should also be dropped
+                let (disposed_tasks, completed_tasks) =
+                    contributor_info.completed_tasks.iter().cloned().partition(|task| {
+                        if let Some(contribution_id) = tasks_by_chunk.get(&task.chunk_id) {
+                            *contribution_id < task.contribution_id
+                        } else {
+                            false
+                        }
+                    });
+                contributor_info.completed_tasks = completed_tasks;
+                contributor_info.disposed_tasks.extend(disposed_tasks);
 
-                    // Add the disposed tasks to the cumulative disposed tasks.
-                    disposed_tasks.extend(contributor_info.disposed_tasks.iter());
+                all_disposed_tasks.extend(contributor_info.disposed_tasks.iter());
 
-                    // Reassign tasks for the affected contributor.
-                    contributor_info.assigned_tasks =
-                        initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors);
+                let mut tasks_to_exclude: HashSet<u64> =
+                    HashSet::from_iter(contributor_info.completed_tasks.iter().map(|task| task.chunk_id));
+                tasks_to_exclude.extend(contributor_info.pending_tasks.iter().map(|task| task.chunk_id));
 
-                    break;
-                }
+                let new_assigned_tasks =
+                    initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors);
+
+                // Reassign tasks for the affected contributor.
+                contributor_info.assigned_tasks = new_assigned_tasks
+                    .into_iter()
+                    .filter(|task| !tasks_to_exclude.contains(&task.chunk_id))
+                    .collect();
             }
 
             // All verifiers assigned to affected tasks must dispose their affected pending tasks.
@@ -1937,7 +1960,7 @@ impl CoordinatorState {
                 let mut pending_tasks = LinkedList::new();
                 for pending_task in verifier_info.pending_tasks.iter() {
                     // Check if the newly disposed tasks contains this pending task.
-                    if disposed_tasks.contains(&pending_task) {
+                    if all_disposed_tasks.contains(&pending_task) {
                         // Move the pending task to the verifier's disposing tasks.
                         verifier_info.disposing_tasks.push_back(pending_task.clone());
                     } else {

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1914,18 +1914,6 @@ impl CoordinatorState {
                 contributor_info.disposing_tasks = disposing_tasks;
                 contributor_info.pending_tasks = pending_tasks;
 
-                // If assigned task is based on the dropped task, it should also be dropped
-                let (disposed_tasks, assigned_tasks) =
-                    contributor_info.assigned_tasks.iter().cloned().partition(|task| {
-                        if let Some(contribution_id) = tasks_by_chunk.get(&task.chunk_id) {
-                            *contribution_id < task.contribution_id
-                        } else {
-                            false
-                        }
-                    });
-                contributor_info.assigned_tasks = assigned_tasks;
-                contributor_info.disposed_tasks = disposed_tasks;
-
                 // If completed task is based on the dropped task, it should also be dropped
                 let (disposed_tasks, completed_tasks) =
                     contributor_info.completed_tasks.iter().cloned().partition(|task| {

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1928,18 +1928,17 @@ impl CoordinatorState {
 
                 all_disposed_tasks.extend(contributor_info.disposed_tasks.iter());
 
-                let mut tasks_to_exclude: HashSet<u64> =
+                // Determine the excluded tasks, which are filtered out from the list of newly assigned tasks.
+                let mut excluded_tasks: HashSet<u64> =
                     HashSet::from_iter(contributor_info.completed_tasks.iter().map(|task| task.chunk_id));
-                tasks_to_exclude.extend(contributor_info.pending_tasks.iter().map(|task| task.chunk_id));
-
-                let new_assigned_tasks =
-                    initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors);
+                excluded_tasks.extend(contributor_info.pending_tasks.iter().map(|task| task.chunk_id));
 
                 // Reassign tasks for the affected contributor.
-                contributor_info.assigned_tasks = new_assigned_tasks
-                    .into_iter()
-                    .filter(|task| !tasks_to_exclude.contains(&task.chunk_id))
-                    .collect();
+                contributor_info.assigned_tasks =
+                    initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors)
+                        .into_iter()
+                        .filter(|task| !excluded_tasks.contains(&task.chunk_id))
+                        .collect();
             }
 
             // All verifiers assigned to affected tasks must dispose their affected pending tasks.

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -334,10 +334,10 @@ impl Storage for Disk {
     fn remove(&mut self, locator: &Locator) -> Result<(), CoordinatorError> {
         trace!("Removing {}", self.to_path(locator)?);
 
-        // Check that the locator does not exist in storage.
+        // Check that the locator exists in storage.
         if !self.exists(&locator) {
-            error!("Locator in call to remove() already exists in storage.");
-            return Err(CoordinatorError::StorageLocatorAlreadyExists);
+            error!("Locator in call to remove() doesn't exist in storage.");
+            return Err(CoordinatorError::StorageLocatorMissing);
         }
 
         // Acquire the manifest file write lock.

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -1074,10 +1074,9 @@ fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
         coordinator.verify(&verifier, &verifier_signing_key)?;
     }
 
-    // Check that coordinator state includes a pending task for contributor 1 and 3.
+    // Aggregate all of the tasks for each of the contributors into a HashSet.
     let contributors = coordinator.current_contributors();
     assert_eq!(3, contributors.len());
-    assert_eq!(1, contributors.par_iter().filter(|(p, _)| *p == contributor2).count());
     let mut tasks: HashSet<Task> = HashSet::new();
     for (_, contributor_info) in contributors {
         tasks.extend(contributor_info.assigned_tasks().iter());
@@ -1157,15 +1156,29 @@ fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
     debug!("{}", serde_json::to_string_pretty(&state)?);
     assert_eq!(1, state.current_round_height());
 
-    // TODO (raychu86): Check all 3 contributors were dropped, coordinator state was updated,
-    //  and the coordinator contributor inherited all the tasks correctly.
-
     let contributors = coordinator.current_contributors();
     assert_eq!(1, contributors.len());
     assert_eq!(0, contributors.par_iter().filter(|(p, _)| *p == contributor1).count());
     assert_eq!(0, contributors.par_iter().filter(|(p, _)| *p == contributor2).count());
     assert_eq!(0, contributors.par_iter().filter(|(p, _)| *p == contributor3).count());
 
+    // TODO (raychu86): Check all 3 contributors were dropped, coordinator state was updated,
+    //  and the coordinator contributor inherited all the tasks correctly.
+
+    // // Aggregate all of the tasks for each of the contributors into a HashSet.
+    // let contributors = coordinator.current_contributors();
+    // let mut tasks: HashSet<Task> = HashSet::new();
+    // for (_, contributor_info) in contributors {
+    //     tasks.extend(contributor_info.assigned_tasks().iter());
+    //     tasks.extend(contributor_info.completed_tasks().iter());
+    //     assert_eq!(0, contributor_info.locked_chunks().len());
+    //     assert_eq!(24, contributor_info.assigned_tasks().len());
+    //     assert_eq!(0, contributor_info.pending_tasks().len());
+    //     assert_eq!(0, contributor_info.completed_tasks().len());
+    //     assert_eq!(0, contributor_info.disposing_tasks().len());
+    //     assert_eq!(0, contributor_info.disposed_tasks().len());
+    // }
+    //
     // // Check that all tasks are present.
     // assert_eq!(24, tasks.len());
     // for chunk_id in 0..environment.number_of_chunks() {

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -229,11 +229,11 @@ fn coordinator_drop_contributor_basic_test() -> anyhow::Result<()> {
     for (contributor, contributor_info) in contributors {
         if contributor == contributor2 {
             assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
+            assert_eq!(4, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(7, contributor_info.completed_tasks().len());
+            assert_eq!(4, contributor_info.completed_tasks().len());
             assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(0, contributor_info.disposed_tasks().len());
+            assert_eq!(3, contributor_info.disposed_tasks().len());
         } else {
             assert_eq!(0, contributor_info.locked_chunks().len());
             assert_eq!(8, contributor_info.assigned_tasks().len());
@@ -343,21 +343,22 @@ fn coordinator_drop_contributor_in_between_two_contributors_test() -> anyhow::Re
     for (contributor, contributor_info) in contributors {
         if contributor == contributor1 {
             tasks.extend(contributor_info.assigned_tasks().iter());
+            tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(8, contributor_info.assigned_tasks().len());
+            assert_eq!(6, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(0, contributor_info.completed_tasks().len());
+            assert_eq!(2, contributor_info.completed_tasks().len());
             assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(8, contributor_info.disposed_tasks().len());
+            assert_eq!(5, contributor_info.disposed_tasks().len());
         } else if contributor == contributor3 {
             tasks.extend(contributor_info.assigned_tasks().iter());
             tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
+            assert_eq!(2, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(7, contributor_info.completed_tasks().len());
+            assert_eq!(6, contributor_info.completed_tasks().len());
             assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(0, contributor_info.disposed_tasks().len());
+            assert_eq!(1, contributor_info.disposed_tasks().len());
         } else {
             tasks.extend(contributor_info.assigned_tasks().iter());
             assert_eq!(0, contributor_info.locked_chunks().len());
@@ -499,21 +500,22 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks_test() -> any
     for (contributor, contributor_info) in contributors {
         if contributor == contributor1 {
             tasks.extend(contributor_info.assigned_tasks().iter());
+            tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(1, contributor_info.locked_chunks().len());
-            assert_eq!(8, contributor_info.assigned_tasks().len());
+            assert_eq!(6, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(0, contributor_info.completed_tasks().len());
+            assert_eq!(2, contributor_info.completed_tasks().len());
             assert_eq!(1, contributor_info.disposing_tasks().len());
-            assert_eq!(7, contributor_info.disposed_tasks().len());
+            assert_eq!(4, contributor_info.disposed_tasks().len());
         } else if contributor == contributor3 {
             tasks.extend(contributor_info.assigned_tasks().iter());
             tasks.extend(contributor_info.pending_tasks().iter());
             tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(1, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
-            assert_eq!(1, contributor_info.pending_tasks().len());
+            assert_eq!(2, contributor_info.assigned_tasks().len());
+            assert_eq!(0, contributor_info.pending_tasks().len());
             assert_eq!(6, contributor_info.completed_tasks().len());
-            assert_eq!(0, contributor_info.disposing_tasks().len());
+            assert_eq!(1, contributor_info.disposing_tasks().len());
             assert_eq!(0, contributor_info.disposed_tasks().len());
         } else {
             tasks.extend(contributor_info.assigned_tasks().iter());
@@ -659,21 +661,22 @@ fn coordinator_drop_contributor_locked_chunks_test() -> anyhow::Result<()> {
     for (contributor, contributor_info) in contributors {
         if contributor == contributor1 {
             tasks.extend(contributor_info.assigned_tasks().iter());
+            tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(1, contributor_info.locked_chunks().len());
-            assert_eq!(8, contributor_info.assigned_tasks().len());
+            assert_eq!(6, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(0, contributor_info.completed_tasks().len());
+            assert_eq!(2, contributor_info.completed_tasks().len());
             assert_eq!(1, contributor_info.disposing_tasks().len());
-            assert_eq!(7, contributor_info.disposed_tasks().len());
+            assert_eq!(4, contributor_info.disposed_tasks().len());
         } else if contributor == contributor3 {
             tasks.extend(contributor_info.assigned_tasks().iter());
             tasks.extend(contributor_info.pending_tasks().iter());
             tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(1, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
-            assert_eq!(1, contributor_info.pending_tasks().len());
+            assert_eq!(2, contributor_info.assigned_tasks().len());
+            assert_eq!(0, contributor_info.pending_tasks().len());
             assert_eq!(6, contributor_info.completed_tasks().len());
-            assert_eq!(0, contributor_info.disposing_tasks().len());
+            assert_eq!(1, contributor_info.disposing_tasks().len());
             assert_eq!(0, contributor_info.disposed_tasks().len());
         } else {
             tasks.extend(contributor_info.assigned_tasks().iter());
@@ -792,11 +795,11 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
     for (contributor, contributor_info) in contributors {
         if contributor == contributor2 {
             assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
+            assert_eq!(4, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(7, contributor_info.completed_tasks().len());
+            assert_eq!(4, contributor_info.completed_tasks().len());
             assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(0, contributor_info.disposed_tasks().len());
+            assert_eq!(3, contributor_info.disposed_tasks().len());
         } else {
             assert_eq!(0, contributor_info.locked_chunks().len());
             assert_eq!(8, contributor_info.assigned_tasks().len());
@@ -980,22 +983,22 @@ fn coordinator_drop_contributor_clear_locks_test() -> anyhow::Result<()> {
     for (contributor, contributor_info) in contributors {
         if contributor == contributor1 {
             tasks.extend(contributor_info.assigned_tasks().iter());
-            assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(8, contributor_info.assigned_tasks().len());
-            assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(0, contributor_info.completed_tasks().len());
-            assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(8, contributor_info.disposed_tasks().len());
-        } else if contributor == contributor3 {
-            tasks.extend(contributor_info.assigned_tasks().iter());
-            tasks.extend(contributor_info.pending_tasks().iter());
             tasks.extend(contributor_info.completed_tasks().iter());
             assert_eq!(0, contributor_info.locked_chunks().len());
-            assert_eq!(1, contributor_info.assigned_tasks().len());
+            assert_eq!(6, contributor_info.assigned_tasks().len());
             assert_eq!(0, contributor_info.pending_tasks().len());
-            assert_eq!(7, contributor_info.completed_tasks().len());
+            assert_eq!(2, contributor_info.completed_tasks().len());
             assert_eq!(0, contributor_info.disposing_tasks().len());
-            assert_eq!(0, contributor_info.disposed_tasks().len());
+            assert_eq!(6, contributor_info.disposed_tasks().len());
+        } else if contributor == contributor3 {
+            tasks.extend(contributor_info.assigned_tasks().iter());
+            tasks.extend(contributor_info.completed_tasks().iter());
+            assert_eq!(0, contributor_info.locked_chunks().len());
+            assert_eq!(2, contributor_info.assigned_tasks().len());
+            assert_eq!(0, contributor_info.pending_tasks().len());
+            assert_eq!(6, contributor_info.completed_tasks().len());
+            assert_eq!(0, contributor_info.disposing_tasks().len());
+            assert_eq!(1, contributor_info.disposed_tasks().len());
         } else {
             tasks.extend(contributor_info.assigned_tasks().iter());
             assert_eq!(0, contributor_info.locked_chunks().len());
@@ -1141,7 +1144,7 @@ fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
 
     // Drop the contributor 3 from the current round.
     let locators = coordinator.drop_participant(&contributor3)?;
-    assert_eq!(&number_of_chunks - 2, locators.len());
+    assert_eq!(&number_of_chunks - 4, locators.len());
     assert!(!coordinator.is_queue_contributor(&contributor1));
     assert!(!coordinator.is_queue_contributor(&contributor2));
     assert!(!coordinator.is_queue_contributor(&contributor3));


### PR DESCRIPTION
With this change `coordinator_drop_multiple_contributors_test` now passes.

- [x] fix panic in call to storage
- [x] fix reallocation of tasks for affected contributors
- [ ] ~~assign all tasks left by dropped contributor to a replacement contributor~~

Affected tests which required an update:
- [x] coordinator_drop_contributor_basic_test
- [x] coordinator_drop_contributor_in_between_two_contributors_test
- [x] coordinator_drop_contributor_with_contributors_in_pending_tasks_test
- [x] coordinator_drop_contributor_locked_chunks_test
- [x] coordinator_drop_contributor_removes_contributions
- [x] coordinator_drop_contributor_clear_locks_test
- [x] coordinator_drop_multiple_contributors_test

The fix for task reallocation is described below. Say, we have 2 contributors, 2 buckets, 4 chunks in each bucket. When we make all contributions, the state is:
```
contributor1 assigned tasks length is 0
contributor1 completed tasks length is 8
contributor2 assigned tasks length is 0
contributor2 completed tasks length is 8
```
When we drop contributor 1, the state before the change would be
```
contributor2 assigned tasks length is 8
contributor2 completed tasks length is 0
contributor2 disposed tasks length is 4
```
After the change from this PR the state would be
```
contributor2 assigned tasks length is 4
contributor2 completed tasks length is 0
contributor2 disposed tasks length is 4
```

Closes #121 