### PR TITLE
Removed failure dependency, fixed some of the cargo audit warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2012,13 +2012,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f1c83949125de4a582aa2da15ae6324d91cf6a58a70ea407643941ff98f558"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.5",
+ "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -2031,7 +2031,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio 0.6.23",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -3369,7 +3369,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "ctrlc",
- "failure",
  "futures-util",
  "hex",
  "lazy_static",
@@ -3878,13 +3877,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -4206,7 +4204,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.7.4",
+ "mio 0.7.7",
  "num_cpus",
  "parking_lot",
  "pin-project-lite 0.1.11",

--- a/setup1-verifier/Cargo.toml
+++ b/setup1-verifier/Cargo.toml
@@ -24,7 +24,6 @@ zexe_algebra = { git = "https://github.com/scipr-lab/zexe", rev = "b24eda5", pac
 anyhow = { version = "1.0.32" }
 chrono = { version = "0.4", features = ["serde"] }
 ctrlc = { version = "3.1.7" }
-failure = { version = "0.1.7" }
 futures-util = { version = "0.3.5" }
 hex = { version = "0.4.2" }
 rand = { version = "0.7.3" }

--- a/setup1-verifier/src/lib.rs
+++ b/setup1-verifier/src/lib.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate thiserror;


### PR DESCRIPTION
Removed unused `failure` from `setup1-verifier`, also fixed some of the `cargo audit` warnings (mostly about yanked crates).