### PR TITLE
Updates for replacement contributors

### DIFF
--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2988,6 +2988,7 @@ fn initialize_tasks(
     tasks
 }
 
+#[derive(Debug)]
 pub(crate) enum Justification {
     BanCurrent(Participant, u64, Vec<u64>, Vec<Task>, Option<Participant>),
     DropCurrent(Participant, u64, Vec<u64>, Vec<Task>, Option<Participant>),

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1960,7 +1960,7 @@ impl CoordinatorState {
                     .cloned()
                     .partition(|task| all_disposed_tasks.contains(&task));
                 verifier_info.completed_tasks = completed_tasks;
-                verifier_info.disposed_tasks = disposed_tasks;
+                verifier_info.disposed_tasks.extend(disposed_tasks);
             }
 
             // Remove the current verifier from the coordinator state.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1911,6 +1911,8 @@ impl CoordinatorState {
                     .cloned()
                     .partition(|task| tasks_by_chunk.get(&task.chunk_id).is_some());
 
+                // TODO: revisit the handling of disposing_tasks
+                //       https://github.com/AleoHQ/aleo-setup/issues/249
                 contributor_info.disposing_tasks = disposing_tasks;
                 contributor_info.pending_tasks = pending_tasks;
 
@@ -1923,6 +1925,9 @@ impl CoordinatorState {
                             false
                         }
                     });
+
+                // TODO: revisit the handling of disposed_tasks
+                //       https://github.com/AleoHQ/aleo-setup/issues/249
                 contributor_info.completed_tasks = completed_tasks;
                 contributor_info.disposed_tasks.extend(disposed_tasks);
 
@@ -1950,6 +1955,9 @@ impl CoordinatorState {
                     .iter()
                     .cloned()
                     .partition(|task| all_disposed_tasks.contains(&task));
+
+                // TODO: revisit the handling of disposing_tasks
+                //       https://github.com/AleoHQ/aleo-setup/issues/249
                 verifier_info.pending_tasks = pending_tasks;
                 verifier_info.disposing_tasks = disposing_tasks;
 
@@ -1959,6 +1967,9 @@ impl CoordinatorState {
                     .iter()
                     .cloned()
                     .partition(|task| all_disposed_tasks.contains(&task));
+
+                // TODO: revisit the handling of disposed_tasks
+                //       https://github.com/AleoHQ/aleo-setup/issues/249
                 verifier_info.completed_tasks = completed_tasks;
                 verifier_info.disposed_tasks.extend(disposed_tasks);
             }

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -798,8 +798,17 @@ impl Round {
                 if storage.exists(&response_locator) {
                     storage.remove(&response_locator)?;
                 }
+
+                // Removing contribution file signature for pending task
                 let response_signature_locator =
                     Locator::ContributionFileSignature(current_round_height, *chunk_id, next_contribution_id, false);
+                if storage.exists(&response_signature_locator) {
+                    storage.remove(&response_signature_locator)?;
+                }
+
+                // Removing contribution file signature for verified task
+                let response_signature_locator =
+                    Locator::ContributionFileSignature(current_round_height, *chunk_id, next_contribution_id, true);
                 if storage.exists(&response_signature_locator) {
                     storage.remove(&response_signature_locator)?;
                 }
@@ -900,6 +909,14 @@ impl Round {
 
                 // Remove the verified contribution file, if it exists.
                 if let Some(locator) = contribution.get_verified_location() {
+                    let path = storage.to_locator(&locator)?;
+                    if storage.exists(&path) {
+                        storage.remove(&path)?;
+                    }
+                }
+
+                // Remove the verified contribution file signature, if it exists.
+                if let Some(locator) = contribution.get_verified_signature_location() {
                     let path = storage.to_locator(&locator)?;
                     if storage.exists(&path) {
                         storage.remove(&path)?;

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -813,6 +813,8 @@ impl Round {
                     storage.remove(&response_signature_locator)?;
                 }
 
+                // TODO: revisit the logic of removing challenges
+                //       https://github.com/AleoHQ/aleo-setup/issues/250
                 // Remove the next challenge locator if the current response has been verified.
                 if chunk.current_contribution()?.is_verified() {
                     // Fetch whether this is the final contribution of the specified chunk.

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -798,6 +798,11 @@ impl Round {
                 if storage.exists(&response_locator) {
                     storage.remove(&response_locator)?;
                 }
+                let response_signature_locator =
+                    Locator::ContributionFileSignature(current_round_height, *chunk_id, next_contribution_id, false);
+                if storage.exists(&response_signature_locator) {
+                    storage.remove(&response_signature_locator)?;
+                }
 
                 // Remove the next challenge locator if the current response has been verified.
                 if chunk.current_contribution()?.is_verified() {
@@ -816,7 +821,8 @@ impl Round {
                             true,
                         )
                     };
-                    if storage.exists(&contribution_file) {
+                    // Don't remove initial challenge
+                    if storage.exists(&contribution_file) && chunk.current_contribution()?.get_contributor().is_some() {
                         storage.remove(&contribution_file)?;
                     }
                 }
@@ -878,6 +884,14 @@ impl Round {
 
                 // Remove the unverified contribution file, if it exists.
                 if let Some(locator) = contribution.get_contributed_location() {
+                    let path = storage.to_locator(&locator)?;
+                    if storage.exists(&path) {
+                        storage.remove(&path)?;
+                    }
+                }
+
+                // Remove the contribution signature file, if it exists.
+                if let Some(locator) = contribution.get_contributed_signature_location() {
                     let path = storage.to_locator(&locator)?;
                     if storage.exists(&path) {
                         storage.remove(&path)?;

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -21,7 +21,7 @@ pub enum Locator {
     RoundHeight,
     RoundState(u64),
     RoundFile(u64),
-    /// round_height, chunk_id, contribution_id, some bool - probably "is verified"
+    /// (round_height, chunk_id, contribution_id, is_verified)
     ContributionFile(u64, u64, u64, bool),
     ContributionFileSignature(u64, u64, u64, bool),
 }

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -21,6 +21,7 @@ pub enum Locator {
     RoundHeight,
     RoundState(u64),
     RoundFile(u64),
+    /// round_height, chunk_id, contribution_id, some bool - probably "is verified"
     ContributionFile(u64, u64, u64, bool),
     ContributionFileSignature(u64, u64, u64, bool),
 }

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -1164,14 +1164,14 @@ fn coordinator_drop_contributor_and_release_locks() {
     // Unwraps are used to find out the exact line which produces the error
     // When the test returns Result with an Err, the line is unknown
 
-    let parameters = Parameters::Custom((
-        ContributionMode::Chunked,
-        ProvingSystem::Groth16,
-        CurveKind::Bls12_377,
-        1, /* power */
-        2, /* batch_size */
-        2, /* chunk_size */
-    ));
+    let parameters = Parameters::Custom(Settings {
+        contribution_mode: ContributionMode::Chunked,
+        proving_system: ProvingSystem::Groth16,
+        curve: CurveKind::Bls12_377,
+        power: 1,
+        batch_size: 2,
+        chunk_size: 2,
+    });
     let replacement_contributor = create_contributor_test_details("replacement-1");
     let testing = Testing::from(parameters).coordinator_contributors(&[replacement_contributor.participant.clone()]);
     let environment = initialize_test_environment(&testing.into());
@@ -1240,14 +1240,14 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     // Unwraps are used to find out the exact line which produces the error
     // When the test returns Result with an Err, the line is unknown
 
-    let parameters = Parameters::Custom((
-        ContributionMode::Chunked,
-        ProvingSystem::Groth16,
-        CurveKind::Bls12_377,
-        1, /* power */
-        2, /* batch_size */
-        2, /* chunk_size */
-    ));
+    let parameters = Parameters::Custom(Settings {
+        contribution_mode: ContributionMode::Chunked,
+        proving_system: ProvingSystem::Groth16,
+        curve: CurveKind::Bls12_377,
+        power: 1,
+        batch_size: 2,
+        chunk_size: 2,
+    });
     let replacement_contributor = create_contributor_test_details("replacement-1");
     let testing = Testing::from(parameters).coordinator_contributors(&[replacement_contributor.participant.clone()]);
     let environment = initialize_test_environment(&testing.into());

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -63,6 +63,25 @@ fn create_contributor_test_details(id: &str) -> ContributorTestDetails {
     }
 }
 
+struct VerifierTestDetails {
+    participant: Participant,
+    signing_key: SigningKey,
+}
+
+impl VerifierTestDetails {
+    fn verify(&self, coordinator: &Coordinator) -> anyhow::Result<()> {
+        coordinator.verify(&self.participant, &self.signing_key)
+    }
+}
+
+fn create_verifier_test_details(id: &str) -> VerifierTestDetails {
+    let (participant, signing_key) = create_verifier(id);
+    VerifierTestDetails {
+        participant,
+        signing_key,
+    }
+}
+
 fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -1132,6 +1151,187 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
     }
 
     Ok(())
+}
+
+fn inspect_verifiers(coordinator: &Coordinator) {
+    for (verifier, verifier_info) in coordinator.current_verifiers() {
+        println!("Inspecting verifier {:?}", verifier);
+        println!("verifier info is {:?}", verifier_info);
+    }
+}
+
+/// Drops a contributor and release the locks
+///
+/// The key part of this test is that we lock a chunk
+/// by a contributor and then immediately drop the contributor
+/// without contributing
+#[test]
+#[serial]
+fn coordinator_drop_contributor_and_release_locks() {
+    // Unwraps are used to find out the exact line which produces the error
+    // When the test returns Result with an Err, the line is unknown
+
+    let parameters = Parameters::Custom((
+        ContributionMode::Chunked,
+        ProvingSystem::Groth16,
+        CurveKind::Bls12_377,
+        1, /* power */
+        2, /* batch_size */
+        2, /* chunk_size */
+    ));
+    let replacement_contributor = create_contributor_test_details("replacement-1");
+    let testing = Testing::from(parameters).coordinator_contributors(&[replacement_contributor.participant.clone()]);
+    let environment = initialize_test_environment_with_debug(&testing.into());
+    let number_of_chunks = environment.number_of_chunks() as usize;
+
+    // Instantiate a coordinator.
+    let coordinator = Coordinator::new(environment, Box::new(Dummy)).unwrap();
+
+    // Initialize the ceremony to round 0.
+    coordinator.initialize().unwrap();
+    assert_eq!(0, coordinator.current_round_height().unwrap());
+
+    // Add a contributor and verifier to the queue.
+    let contributor_1 = create_contributor_test_details("1");
+    let contributor_2 = create_contributor_test_details("2");
+    let verifier_1 = create_verifier_test_details("1");
+    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
+    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator.add_to_queue(verifier_1.participant.clone(), 10).unwrap();
+
+    // Update the ceremony to round 1.
+    coordinator.update().unwrap();
+
+    // Lock a chunk by a contributor
+    coordinator.try_lock(&contributor_1.participant).unwrap();
+
+    // Drop the contributor which have locked the chunk
+    let locators = coordinator.drop_participant(&contributor_1.participant).unwrap();
+    assert_eq!(0, locators.len());
+
+    // Contribute to the round 1
+    for _ in 0..number_of_chunks {
+        replacement_contributor.contribute_to(&coordinator).unwrap();
+        contributor_2.contribute_to(&coordinator).unwrap();
+        verifier_1.verify(&coordinator).unwrap();
+        verifier_1.verify(&coordinator).unwrap();
+    }
+
+    // Add some more participants to proceed to the next round
+    let test_contributor_3 = create_contributor_test_details("3");
+    let test_contributor_4 = create_contributor_test_details("4");
+    let verifier_2 = create_verifier_test_details("2");
+    coordinator
+        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .unwrap();
+    coordinator.add_to_queue(verifier_2.participant.clone(), 10).unwrap();
+
+    // Update the ceremony to round 2.
+    coordinator.update().unwrap();
+    assert_eq!(2, coordinator.current_round_height().unwrap());
+    assert_eq!(0, coordinator.number_of_queue_contributors());
+    assert_eq!(0, coordinator.number_of_queue_verifiers());
+}
+
+/// Drops a contributor and update verifier tasks
+///
+/// Make one contribution and verify it, then drop the
+/// contributor. The tasks of a verifier should be updated
+/// properly
+#[test]
+#[serial]
+fn coordinator_drop_contributor_and_update_verifier_tasks() {
+    // Unwraps are used to find out the exact line which produces the error
+    // When the test returns Result with an Err, the line is unknown
+
+    let parameters = Parameters::Custom((
+        ContributionMode::Chunked,
+        ProvingSystem::Groth16,
+        CurveKind::Bls12_377,
+        1, /* power */
+        2, /* batch_size */
+        2, /* chunk_size */
+    ));
+    let replacement_contributor = create_contributor_test_details("replacement-1");
+    let testing = Testing::from(parameters).coordinator_contributors(&[replacement_contributor.participant.clone()]);
+    let environment = initialize_test_environment_with_debug(&testing.into());
+    let number_of_chunks = environment.number_of_chunks() as usize;
+
+    // Instantiate a coordinator.
+    let coordinator = Coordinator::new(environment, Box::new(Dummy)).unwrap();
+
+    // Initialize the ceremony to round 0.
+    coordinator.initialize().unwrap();
+    assert_eq!(0, coordinator.current_round_height().unwrap());
+
+    // Add a contributor and verifier to the queue.
+    let contributor_1 = create_contributor_test_details("1");
+    let contributor_2 = create_contributor_test_details("2");
+    let verifier_1 = create_verifier_test_details("1");
+    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
+    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator.add_to_queue(verifier_1.participant.clone(), 10).unwrap();
+
+    // Update the ceremony to round 1.
+    coordinator.update().unwrap();
+
+    println!("Manifest before we contribute");
+    // coordinator.inspect_storage();
+    inspect_verifiers(&coordinator);
+
+    contributor_1.contribute_to(&coordinator).unwrap();
+
+    println!("Manifest after we contribute");
+    // coordinator.inspect_storage();
+    inspect_verifiers(&coordinator);
+
+    verifier_1.verify(&coordinator).unwrap();
+
+    println!("Manifest after we verify");
+    // coordinator.inspect_storage();
+    inspect_verifiers(&coordinator);
+
+    // Drop one contributor
+    let locators = coordinator.drop_participant(&contributor_1.participant).unwrap();
+    assert_eq!(1, locators.len());
+
+    println!("Manifest after we drop participant");
+    inspect_verifiers(&coordinator);
+    // coordinator.inspect_storage();
+
+    // Contribute to the round 1
+    for i in 0..number_of_chunks {
+        println!("\n\n\n");
+        replacement_contributor.contribute_to(&coordinator).unwrap();
+        println!("before contributor 2 contributes, i is {}", i);
+        contributor_2.contribute_to(&coordinator).unwrap();
+        println!("after contributor 2 contributes, i is {}", i);
+        verifier_1.verify(&coordinator).unwrap();
+        verifier_1.verify(&coordinator).unwrap();
+        println!("verification done, next loop, i is {}", i);
+        println!("\n\n\n");
+    }
+
+    // Add some more participants to proceed to the next round
+    let test_contributor_3 = create_contributor_test_details("3");
+    let test_contributor_4 = create_contributor_test_details("4");
+    let verifier_2 = create_verifier_test_details("2");
+    coordinator
+        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .unwrap();
+    coordinator.add_to_queue(verifier_2.participant.clone(), 10).unwrap();
+
+    // Update the ceremony to round 2.
+    coordinator.update().unwrap();
+    assert_eq!(2, coordinator.current_round_height().unwrap());
+    assert_eq!(0, coordinator.number_of_queue_contributors());
+    assert_eq!(0, coordinator.number_of_queue_verifiers());
 }
 
 /// Drops a multiple contributors an replaces with the coordinator contributor.


### PR DESCRIPTION
A number of changes related to a drop contributor logic:
- Now locks for contribution file signatures are also cleared
- Verifier's completed tasks are now updated
- Initial challenge locator is not removed anymore
- Added two new tests, and changed one old test

Closes #232 
Closes #235 
