### PR TITLE
RUST_LOG env for tests

### DIFF
--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -47,5 +47,3 @@ default = ["log_file"]
 operator = ["log_file", "testing"]
 testing = []
 log_file = []
-silent = []
-

--- a/phase1-coordinator/README.md
+++ b/phase1-coordinator/README.md
@@ -43,9 +43,15 @@ cargo test
 
 ### Logging
 
-Logging is enabled by default during tests. To silence all logs, run:
+Logging is enabled by default during tests. Use `RUST_LOG` env variable to configure
+the log levels:
+```bash
+RUST_LOG=debug cargo test
 ```
-cargo test --features silent
+
+Default log level is `error`. To completely hide the logs use:
+```bash
+RUST_LOG=none cargo test
 ```
 
 ### Serial Test Execution

--- a/phase1-coordinator/src/logger.rs
+++ b/phase1-coordinator/src/logger.rs
@@ -2,21 +2,16 @@ use crate::environment::Environment;
 
 use once_cell::sync::OnceCell;
 
-#[cfg(feature = "silent")]
+#[cfg(not(feature = "log_file"))]
 pub struct LogGuard;
-#[cfg(all(not(feature = "silent"), not(feature = "log_file")))]
-pub struct LogGuard;
-#[cfg(all(not(feature = "silent"), feature = "log_file"))]
+#[cfg(feature = "log_file")]
 pub struct LogGuard(tracing_appender::non_blocking::WorkerGuard);
 
 pub(crate) static LOGGER: OnceCell<LogGuard> = OnceCell::new();
 
 /// Initialize logger with custom format and verbosity.
 pub(crate) fn initialize_logger(environment: &Environment) {
-    #[cfg(feature = "silent")]
-    LOGGER.get_or_init(|| LogGuard {});
-
-    #[cfg(all(not(feature = "silent"), not(feature = "log_file")))]
+    #[cfg(not(feature = "log_file"))]
     LOGGER.get_or_init(|| {
         use tracing_subscriber::{fmt::format::Format, FmtSubscriber};
 
@@ -35,7 +30,7 @@ pub(crate) fn initialize_logger(environment: &Environment) {
         LogGuard {}
     });
 
-    #[cfg(all(not(feature = "silent"), feature = "log_file"))]
+    #[cfg(feature = "log_file")]
     LOGGER.get_or_init(|| {
         use tracing_subscriber::{fmt, fmt::format::Format, layer::SubscriberExt, FmtSubscriber};
 

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -20,7 +20,6 @@ use tracing::*;
 
 use once_cell::sync::OnceCell;
 
-
 static INSTANCE: OnceCell<()> = OnceCell::new();
 
 /// Environment for testing purposes only.

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -18,10 +18,9 @@ use std::{
 };
 use tracing::*;
 
-#[cfg(not(feature = "silent"))]
 use once_cell::sync::OnceCell;
 
-#[cfg(not(feature = "silent"))]
+
 static INSTANCE: OnceCell<()> = OnceCell::new();
 
 /// Environment for testing purposes only.
@@ -82,34 +81,17 @@ pub fn test_coordinator_verifier(environment: &Environment) -> anyhow::Result<Pa
 }
 
 pub fn initialize_test_environment(environment: &Environment) -> Environment {
-    #[cfg(not(feature = "silent"))]
     test_logger();
 
     clear_test_storage(environment);
     environment.clone()
 }
 
-pub fn initialize_test_environment_with_debug(environment: &Environment) -> Environment {
-    #[cfg(not(feature = "silent"))]
-    INSTANCE.get_or_init(|| {
-        let subscriber = tracing_subscriber::fmt().with_max_level(Level::DEBUG).finish();
-        tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-    });
-
-    clear_test_storage(environment);
-    environment.clone()
-}
-
-#[cfg(not(feature = "silent"))]
 pub(crate) fn test_logger() {
     INSTANCE.get_or_init(|| {
-        let subscriber = tracing_subscriber::fmt().with_max_level(Level::TRACE).finish();
-        tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+        tracing_subscriber::fmt::init();
     });
 }
-
-#[cfg(feature = "silent")]
-pub(crate) fn test_logger() {}
 
 /// Clears the transcript directory for testing purposes only.
 fn clear_test_storage(environment: &Environment) {

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -72,7 +72,7 @@ fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow
         32, /* batch_size */
         32, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -178,7 +178,7 @@ fn coordinator_drop_contributor_basic_test() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -294,7 +294,7 @@ fn coordinator_drop_contributor_in_between_two_contributors_test() -> anyhow::Re
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -422,7 +422,7 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks_test() -> any
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -580,7 +580,7 @@ fn coordinator_drop_contributor_locked_chunks_test() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -744,7 +744,7 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -871,7 +871,7 @@ fn coordinator_drop_contributor_clear_locks_test() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -1070,7 +1070,7 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
     ));
     let (replacement_contributor, ..) = create_contributor("replacement-1");
     let testing = Testing::from(parameters).coordinator_contributors(&[replacement_contributor.clone()]);
-    let environment = initialize_test_environment_with_debug(&testing.into());
+    let environment = initialize_test_environment(&testing.into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -1149,7 +1149,7 @@ fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
         Participant::new_contributor("testing-coordinator-contributor-2"),
         Participant::new_contributor("testing-coordinator-contributor-3"),
     ]);
-    let environment = initialize_test_environment_with_debug(&testing.into());
+    let environment = initialize_test_environment(&testing.into());
 
     let number_of_chunks = environment.number_of_chunks() as usize;
 
@@ -1309,7 +1309,7 @@ fn try_lock_blocked_test() -> anyhow::Result<()> {
         32, /* batch_size */
         32, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -1421,7 +1421,7 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
         replacement_contributor_1.participant.clone(),
         replacement_contributor_2.participant.clone(),
     ]);
-    let environment = initialize_test_environment_with_debug(&testing.into());
+    let environment = initialize_test_environment(&testing.into());
 
     let number_of_chunks = environment.number_of_chunks() as usize;
 
@@ -1502,7 +1502,7 @@ fn drop_contributor_and_reassign_tasks_test() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-    let environment = initialize_test_environment_with_debug(&Testing::from(parameters).into());
+    let environment = initialize_test_environment(&Testing::from(parameters).into());
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.


### PR DESCRIPTION
Two main changes here are:
- used `RUST_LOG` env variable to initialize logs in tests. Default log level is `error`
- removed `silent` feature. Use `RUST_LOG` instead to configure the log levels

As one of the benefits we no longer need to recompile the crate to hide the logs, just use the different level in `RUST_LOG`

Closes #238 