### PR TITLE
Standard cargo report in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,26 +1206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
-name = "function_name"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b2afa9b514dc3a75af6cf24d1914e1c7eb6f1b86de849147563548d5c0a0cd"
-dependencies = [
- "function_name-proc-macro",
-]
-
-[[package]]
-name = "function_name-proc-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6790a8d356d2f65d7972181e866b92a50a87c27d6a48cbe9dbb8be13ca784c7d"
-dependencies = [
- "proc-macro-crate",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "futures"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,7 +2431,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "ctrlc",
- "function_name",
  "hex",
  "itertools",
  "memmap",
@@ -2628,15 +2607,6 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
 
 [[package]]
 name = "proc-macro-error"

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -38,7 +38,6 @@ tracing-subscriber = { version = "0.2" }
 url = { version = "1.0" }
 
 [dev-dependencies]
-function_name = { version = "0.2.0" }
 once_cell = { version = "1.5.2" }
 serial_test = { version = "0.5" }
 

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -2598,7 +2598,9 @@ mod tests {
         initialize_to_round_1(coordinator, &contributors, &verifiers)
     }
 
-    fn coordinator_initialization_matches_json_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_initialization_matches_json() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT);
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT.clone(), Box::new(Dummy))?;
@@ -2624,7 +2626,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_initialization_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_initialization() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT);
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT.clone(), Box::new(Dummy))?;
@@ -2690,7 +2694,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_contributor_try_lock_chunk_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_contributor_try_lock_chunk() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT);
 
         let contributor = Lazy::force(&TEST_CONTRIBUTOR_ID);
@@ -2756,7 +2762,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_contributor_add_contribution_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_contributor_add_contribution() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT_3);
 
         let contributor = Lazy::force(&TEST_CONTRIBUTOR_ID).clone();
@@ -2831,7 +2839,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_verifier_verify_contribution_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_verifier_verify_contribution() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT_3);
 
         let contributor = Lazy::force(&TEST_CONTRIBUTOR_ID);
@@ -2929,10 +2939,12 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    #[serial]
     // This test runs a round with a single coordinator and single verifier
     // The verifier instances are run on a separate thread to simulate an environment where
     // verification and contribution happen concurrently.
-    fn coordinator_concurrent_contribution_verification_test() -> anyhow::Result<()> {
+    fn coordinator_concurrent_contribution_verification() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT_3);
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT_3.clone(), Box::new(Dummy))?;
@@ -3075,7 +3087,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_aggregation_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_aggregation() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT_3);
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT_3.clone(), Box::new(Dummy))?;
@@ -3238,7 +3252,9 @@ mod tests {
         Ok(())
     }
 
-    fn coordinator_next_round_test() -> anyhow::Result<()> {
+    #[test]
+    #[serial]
+    fn coordinator_next_round() -> anyhow::Result<()> {
         initialize_test_environment(&TEST_ENVIRONMENT_3);
 
         let coordinator = Coordinator::new(TEST_ENVIRONMENT_3.clone(), Box::new(Dummy))?;
@@ -3407,63 +3423,8 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_coordinator_initialization_matches_json() {
-        coordinator_initialization_matches_json_test().unwrap();
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_initialization() {
-        test_report!(coordinator_initialization_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_contributor_try_lock_chunk() {
-        test_report!(coordinator_contributor_try_lock_chunk_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_contributor_add_contribution() {
-        test_report!(coordinator_contributor_add_contribution_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_verifier_verify_contribution() {
-        test_report!(coordinator_verifier_verify_contribution_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_concurrent_contribution_verification() {
-        test_report!(coordinator_concurrent_contribution_verification_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_aggregation() {
-        test_report!(coordinator_aggregation_test);
-    }
-
-    #[test]
-    #[named]
-    #[serial]
-    fn test_coordinator_next_round() {
-        test_report!(coordinator_next_round_test);
-    }
-
-    #[test]
-    #[serial]
     #[ignore]
-    fn test_coordinator_number_of_chunks() {
+    fn coordinator_number_of_chunks() {
         let environment = &*Testing::from(Parameters::TestChunks { number_of_chunks: 4096 });
         initialize_test_environment(environment);
 

--- a/phase1-coordinator/src/macros.rs
+++ b/phase1-coordinator/src/macros.rs
@@ -127,11 +127,3 @@ macro_rules! return_error {
         return $error;
     }};
 }
-
-#[cfg(test)]
-#[macro_export]
-macro_rules! test_report {
-    ($function:expr) => {{
-        test_report(function_name!(), $function);
-    }};
-}

--- a/phase1-coordinator/src/testing/prelude.rs
+++ b/phase1-coordinator/src/testing/prelude.rs
@@ -1,46 +1,6 @@
 pub use super::coordinator::*;
 
-#[cfg(test)]
-pub use function_name::named;
 pub use serde_diff::{Apply, Diff, SerdeDiff};
 #[cfg(test)]
 pub use serial_test::serial;
 pub use tracing::*;
-
-use std::panic::{catch_unwind, RefUnwindSafe};
-
-#[cfg(test)]
-const BAR: &str = "\n\n-----------------------------------------------------------------------------\n\n";
-
-#[cfg(test)]
-pub fn test_report<T, F>(name: &str, function: F)
-where
-    F: Fn() -> anyhow::Result<T> + RefUnwindSafe,
-{
-    match catch_unwind(|| function()) {
-        Ok(outcome) => match &outcome {
-            Ok(_) => {
-                let message = format!("{} [SUCCESS] {} passed.{}", BAR, name, BAR);
-                info!("{}", message);
-                println!("{}", message);
-                outcome.unwrap();
-            }
-            Err(error) => {
-                let message = format!("{}{}{}{} [FAILURE] {} errored.{}", BAR, error, BAR, BAR, name, BAR);
-                println!("{}", message);
-                outcome.unwrap();
-            }
-        },
-        Err(error) => match error.downcast::<String>() {
-            Ok(message) => {
-                let message = format!("{}{}{}{} [FAILURE] {} failed.{}", BAR, message, BAR, BAR, name, BAR);
-                panic!(message);
-            }
-            Err(error) => {
-                let message = format!("{} [PANIC] {} panicked.{}", BAR, name, BAR);
-                println!("{}", message);
-                panic!(error);
-            }
-        },
-    };
-}

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -63,7 +63,7 @@ fn create_contributor_test_details(id: &str) -> ContributorTestDetails {
     }
 }
 
-fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Result<()> {
+fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         proving_system,
@@ -130,22 +130,22 @@ fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow
 /*
     Drop Participant Tests
 
-    1. Basic drop - `test_coordinator_drop_contributor_basic`
+    1. Basic drop - `coordinator_drop_contributor_basic`
         Drop a contributor that does not affect other contributors/verifiers.
 
-    2. Given 3 contributors, drop middle contributor - `test_coordinator_drop_contributor_in_between_two_contributors`
+    2. Given 3 contributors, drop middle contributor - `coordinator_drop_contributor_in_between_two_contributors`
         Given contributors 1, 2, and 3, drop contributor 2 and ensure that the tasks are present.
 
-    3. Drop contributor with pending tasks - `test_coordinator_drop_contributor_with_contributors_in_pending_tasks`
+    3. Drop contributor with pending tasks - `coordinator_drop_contributor_with_contributors_in_pending_tasks`
         Drops a contributor with other contributors in pending tasks.
 
-    4. Drop contributor with a locked chunk - `test_coordinator_drop_contributor_with_locked_chunk`
+    4. Drop contributor with a locked chunk - `coordinator_drop_contributor_with_locked_chunk`
         Test that dropping a contributor releases the locks held by the dropped contributor.
 
-    5. Dropping a contributor removes provided contributions - `test_coordinator_drop_contributor_removes_contributions`
+    5. Dropping a contributor removes provided contributions - `coordinator_drop_contributor_removes_contributions`
         Test that dropping a contributor will remove all the contributions that the dropped contributor has provided.
 
-    6. Dropping a participant clears lock for subsequent contributors/verifiers - `test_coordinator_drop_contributor_clear_locks`
+    6. Dropping a participant clears lock for subsequent contributors/verifiers - `coordinator_drop_contributor_clear_locks`
         Test that if a contribution is dropped from a chunk, while a  contributor/verifier is performing their contribution,
         the lock should be released after the task has been disposed. The disposed task should also be reassigned correctly.
         Currently, the lock is release and the task is disposed after the contributor/verifier calls `try_contribute` or `try_verify`.
@@ -154,7 +154,7 @@ fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow
         If a contributor is dropped, all contributions built on top of the dropped contributions must also
         be dropped.
 
-    8. Dropping multiple contributors allocates tasks to the coordinator contributor correctly - `test_coordinator_drop_multiple_contributors`
+    8. Dropping multiple contributors allocates tasks to the coordinator contributor correctly - `coordinator_drop_multiple_contributors`
         Pick contributor with least load in `add_replacement_contributor_unsafe`.
 
     9. Current contributor/verifier `completed_tasks` should be removed/moved when a participant is dropped
@@ -163,13 +163,15 @@ fn execute_round_test(proving_system: ProvingSystem, curve: CurveKind) -> anyhow
 
     10. The coordinator contributor should replace all dropped participants and complete the round correctly. - `drop_all_contributors_and_complete_round`
 
-    11. Drop one contributor and check that completed tasks are reassigned properly, - `drop_contributor_and_reassign_tasks_test`
+    11. Drop one contributor and check that completed tasks are reassigned properly, - `drop_contributor_and_reassign_tasks`
         as well as a replacement contributor has the right amount of tasks assigned
 
 */
 
+#[test]
+#[serial]
 /// Drops a contributor who does not affect other contributors or verifiers.
-fn coordinator_drop_contributor_basic_test() -> anyhow::Result<()> {
+fn coordinator_drop_contributor_basic() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -284,8 +286,10 @@ fn coordinator_drop_contributor_basic_test() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a contributor in between two contributors.
-fn coordinator_drop_contributor_in_between_two_contributors_test() -> anyhow::Result<()> {
+fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -412,8 +416,10 @@ fn coordinator_drop_contributor_in_between_two_contributors_test() -> anyhow::Re
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a contributor with other contributors in pending tasks.
-fn coordinator_drop_contributor_with_contributors_in_pending_tasks_test() -> anyhow::Result<()> {
+fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -570,8 +576,10 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks_test() -> any
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a contributor with locked chunks and other contributors in pending tasks.
-fn coordinator_drop_contributor_locked_chunks_test() -> anyhow::Result<()> {
+fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -734,6 +742,8 @@ fn coordinator_drop_contributor_locked_chunks_test() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a contributor and removes all contributions from the contributor.
 fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
@@ -861,8 +871,10 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a contributor and clears locks for contributors/verifiers working on disposed tasks.
-fn coordinator_drop_contributor_clear_locks_test() -> anyhow::Result<()> {
+fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -1134,8 +1146,10 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
     Ok(())
 }
 
+#[test]
+#[serial]
 /// Drops a multiple contributors an replaces with the coordinator contributor.
-fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
+fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -1300,7 +1314,9 @@ fn coordinator_drop_multiple_contributors_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn try_lock_blocked_test() -> anyhow::Result<()> {
+#[test]
+#[serial]
+fn try_lock_blocked() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -1493,7 +1509,9 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn drop_contributor_and_reassign_tasks_test() -> anyhow::Result<()> {
+#[test]
+#[serial]
+fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
@@ -1570,81 +1588,18 @@ fn drop_contributor_and_reassign_tasks_test() -> anyhow::Result<()> {
 
 #[test]
 #[serial]
-fn test_round_on_groth16_bls12_377() {
-    execute_round_test(ProvingSystem::Groth16, CurveKind::Bls12_377).unwrap();
+fn round_on_groth16_bls12_377() {
+    execute_round(ProvingSystem::Groth16, CurveKind::Bls12_377).unwrap();
 }
 
 #[test]
 #[serial]
-fn test_round_on_groth16_bw6_761() {
-    execute_round_test(ProvingSystem::Groth16, CurveKind::BW6).unwrap();
+fn round_on_groth16_bw6_761() {
+    execute_round(ProvingSystem::Groth16, CurveKind::BW6).unwrap();
 }
 
 #[test]
 #[serial]
-fn test_round_on_marlin_bls12_377() {
-    execute_round_test(ProvingSystem::Marlin, CurveKind::Bls12_377).unwrap();
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_basic() {
-    test_report!(coordinator_drop_contributor_basic_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_in_between_two_contributors() {
-    test_report!(coordinator_drop_contributor_in_between_two_contributors_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_with_contributors_in_pending_tasks() {
-    test_report!(coordinator_drop_contributor_with_contributors_in_pending_tasks_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_with_locked_chunk() {
-    test_report!(coordinator_drop_contributor_locked_chunks_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_removes_contributions() {
-    test_report!(coordinator_drop_contributor_removes_contributions);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_contributor_clear_locks() {
-    test_report!(coordinator_drop_contributor_clear_locks_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_coordinator_drop_multiple_contributors() {
-    test_report!(coordinator_drop_multiple_contributors_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_try_lock_blocked() {
-    test_report!(try_lock_blocked_test);
-}
-
-#[test]
-#[named]
-#[serial]
-fn test_drop_contributor_and_reassign_tasks() {
-    test_report!(drop_contributor_and_reassign_tasks_test);
+fn round_on_marlin_bls12_377() {
+    execute_round(ProvingSystem::Marlin, CurveKind::Bls12_377).unwrap();
 }


### PR DESCRIPTION
- Removed `test_report` macro and function
- Removed duplication of the word `test` in some test names, because default report already adds it:
```
test tests::round_on_groth16_bw6_761 ... ok
test tests::round_on_marlin_bls12_377 ... ok
test tests::try_lock_blocked ... ok
```

Closes #239 