### PR TITLE
Fix/drop participant timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "setup-utils",
+ "thiserror",
  "tokio 0.3.1",
  "tracing",
  "tracing-appender",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,8 +938,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
+dependencies = [
+ "darling_core 0.12.2",
+ "darling_macro 0.12.2",
 ]
 
 [[package]]
@@ -957,12 +967,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b443e5fb0ddd56e0c9bfa47dc060c5306ee500cb731f2b91432dd65589a77684"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "strsim 0.10.0",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
+ "darling_core 0.10.2",
+ "quote 1.0.7",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
+dependencies = [
+ "darling_core 0.12.2",
  "quote 1.0.7",
  "syn 1.0.60",
 ]
@@ -2489,6 +2524,7 @@ dependencies = [
  "serde-aux",
  "serde-diff",
  "serde_json",
+ "serde_with",
  "serial_test",
  "setup-utils",
  "tokio 0.3.1",
@@ -3105,6 +3141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "rusty-hook"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,7 +3352,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692563b61324ae1568e2884c7a6385ab4b95f13063fd31a6b702d5cbc5c456df"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.60",
@@ -3370,6 +3412,30 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e557c650adfb38b32a5aec07082053253c703bc3cec654b27a5dbcf61995bb9b"
+dependencies = [
+ "chrono",
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
+dependencies = [
+ "darling 0.12.2",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
 ]
 
 [[package]]

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -32,6 +32,7 @@ serde-aux = { version = "0.6" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
 serde_with = { version = "1.8", features = ["chrono", "macros"] }
+thiserror = { version = "1.0" }
 tokio = { version = "0.3", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-appender = { version = "0.1" }

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-aux = { version = "0.6" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
+serde_with = { version = "1.8", features = ["chrono", "macros"] }
 tokio = { version = "0.3", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-appender = { version = "0.1" }

--- a/phase1-coordinator/README.md
+++ b/phase1-coordinator/README.md
@@ -27,6 +27,9 @@ This command will lock the queue, and begin the prepare commit phase for transit
 the coordinator commits to the next round and the ceremony advances by one round. If the coordinator fails to aggregate the current round,
 the commit is rolled back to the current round and all participants assigned to the next round are returned to the queue.
 
+See the documentation in [lib.rs](./src/lib.rs) as an entry point to a more
+detailed explaination of how this library works.
+
 ## Build Guide
 
 To start the coordinator, run:

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -37,6 +37,7 @@ pub enum CoordinatorError {
     ChunkLockLimitReached,
     ChunkMissing,
     ChunkMissingVerification,
+    ChunkCannotLockZeroContributions { chunk_id: u64 },
     ChunkNotLockedOrByWrongParticipant,
     ComputationFailed,
     CompressedContributionHashingUnsupported,

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -2213,8 +2213,8 @@ impl Coordinator {
 
         // Check the justification and extract the tasks.
         let (tasks, replacement) = match justification {
-            Justification::BanCurrent(_, _, _, ref tasks, ref replacement) => (tasks, replacement),
-            Justification::DropCurrent(_, _, _, ref tasks, ref replacement) => (tasks, replacement),
+            Justification::BanCurrent(data) => (&data.tasks, &data.replacement),
+            Justification::DropCurrent(data) => (&data.tasks, &data.replacement),
             Justification::Inactive => {
                 warn!("Justification for action is that participant is inactive");
                 return Ok(vec![]);

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -3,7 +3,7 @@ use crate::{
     commands::{Aggregation, Initialization},
     coordinator_state::{CoordinatorState, Justification, ParticipantInfo, RoundMetrics},
     environment::{Deployment, Environment},
-    objects::{participant::*, ContributionFileSignature, Round},
+    objects::{participant::*, task::TaskInitializationError, ContributionFileSignature, Round},
     storage::{Locator, Object, Storage, StorageLock},
 };
 use setup_utils::calculate_hash;
@@ -175,6 +175,7 @@ pub enum CoordinatorError {
     StorageReaderFailed,
     StorageSizeLookupFailed,
     StorageUpdateFailed,
+    TaskInitializationFailed(TaskInitializationError),
     TryFromSliceError(std::array::TryFromSliceError),
     UnauthorizedChunkContributor,
     UnauthorizedChunkVerifier,
@@ -184,6 +185,12 @@ pub enum CoordinatorError {
     VerifierMissing,
     VerifierSignatureInvalid,
     VerifiersMissing,
+}
+
+impl From<TaskInitializationError> for CoordinatorError {
+    fn from(error: TaskInitializationError) -> Self {
+        Self::TaskInitializationFailed(error)
+    }
 }
 
 impl From<anyhow::Error> for CoordinatorError {

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -253,7 +253,7 @@ impl From<CoordinatorError> for anyhow::Error {
 
 /// A trait for providing a source of time to the coordinator, used
 /// for mocking system time during testing.
-pub(crate) trait TimeSource: Send + Sync {
+pub trait TimeSource: Send + Sync {
     /// Provide the current time now in the UTC timezone
     fn utc_now(&self) -> DateTime<Utc>;
 }
@@ -275,7 +275,7 @@ impl TimeSource for SystemTimeSource {
 
 /// A time source to use for testing, allows the current time to be
 /// set manually.
-pub(crate) struct MockTimeSource {
+pub struct MockTimeSource {
     time: RwLock<DateTime<Utc>>,
 }
 
@@ -335,7 +335,7 @@ impl Coordinator {
     }
 
     /// Constructor that allows mocking time for testing.
-    pub(crate) fn new_with_time(
+    pub fn new_with_time(
         environment: Environment,
         signature: Box<dyn Signature>,
         time: Arc<dyn TimeSource>,

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -118,7 +118,7 @@ pub enum CoordinatorError {
     ParticipantMissing,
     ParticipantMissingDisposingTask,
     ParticipantMissingPendingTask,
-    ParticipantNotFound,
+    ParticipantNotFound(Participant),
     ParticipantNotReady,
     ParticipantRoundHeightInvalid,
     ParticipantRoundHeightMissing,
@@ -999,6 +999,13 @@ impl Coordinator {
             // The given round height does not exist.
             false => Err(CoordinatorError::RoundDoesNotExist),
         }
+    }
+
+    /// Lets the coordinator know that the participant is still alive
+    /// and participating (or waiting to participate) in the ceremony.
+    pub fn heartbeat(&self, participant: &Participant) -> Result<(), CoordinatorError> {
+        let mut state = self.state.write().expect("unable to obtain write lock on state");
+        state.heartbeat(participant, self.time.as_ref())
     }
 
     ///

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -271,6 +271,8 @@ pub trait TimeSource: Send + Sync {
 }
 
 // Private tuple field to force use of constructor.
+/// A [TimeSource] implementation that fetches the current system time
+/// using [Utc].
 pub(crate) struct SystemTimeSource(());
 
 impl SystemTimeSource {

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -1,3 +1,7 @@
+//! This module contains the central piece of this crate, the
+//! [Coordinator]. The coordinator's state is stored in a
+//! [CoordinatorState] object.
+
 use crate::{
     authentication::Signature,
     commands::{Aggregation, Initialization},
@@ -312,7 +316,9 @@ impl TimeSource for MockTimeSource {
     }
 }
 
-/// A core structure for operating the Phase 1 ceremony.
+/// A core structure for operating the Phase 1 ceremony. This struct
+/// is designed to be [Send] + [Sync]. The state of the ceremony is
+/// stored in a [CoordinatorState] object.
 #[derive(Clone)]
 pub struct Coordinator {
     /// The parameters and settings of this coordinator.

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -244,7 +244,10 @@ impl fmt::Display for CoordinatorError {
 impl From<CoordinatorError> for anyhow::Error {
     fn from(error: CoordinatorError) -> Self {
         error!("{}", error);
-        Self::msg(error.to_string())
+        match error {
+            CoordinatorError::Error(anyhow_error) => anyhow_error,
+            _ => Self::msg(error.to_string()),
+        }
     }
 }
 

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1997,7 +1997,7 @@ impl CoordinatorState {
 
                 // Reassign tasks for the affected contributor.
                 contributor_info.assigned_tasks =
-                    initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors)
+                    initialize_tasks(contributor_info.bucket_id, number_of_chunks, number_of_contributors)?
                         .into_iter()
                         .filter(|task| !excluded_tasks.contains(&task.chunk_id()))
                         .collect();
@@ -2157,7 +2157,7 @@ impl CoordinatorState {
         // TODO (raychu86): Update the participant info (interleave the tasks by contribution id).
         // TODO (raychu86): Add tasks to the replacement contributor if it already has pending tasks.
 
-        let tasks = initialize_tasks(bucket_id, self.environment.number_of_chunks(), number_of_contributors);
+        let tasks = initialize_tasks(bucket_id, self.environment.number_of_chunks(), number_of_contributors)?;
         let mut participant_info =
             ParticipantInfo::new(contributor.clone(), self.current_round_height(), 10, bucket_id, time);
         participant_info.start(tasks, time)?;
@@ -2737,7 +2737,7 @@ impl CoordinatorState {
             // Set the chunk ID ordering for each contributor.
             for (bucket_index, (participant, (reliability, next_round))) in contributors.into_iter().enumerate() {
                 let bucket_id = bucket_index as u64;
-                let tasks = initialize_tasks(bucket_id, number_of_chunks, number_of_contributors as u64);
+                let tasks = initialize_tasks(bucket_id, number_of_chunks, number_of_contributors as u64)?;
 
                 // Check that each participant is storing the correct round height.
                 if next_round != next_round_height && next_round != current_round_height + 1 {
@@ -3782,9 +3782,9 @@ mod tests {
 
         // Process every chunk in the round as contributor 1 and contributor 2.
         let number_of_chunks = environment.number_of_chunks();
-        let tasks1 = initialize_tasks(0, number_of_chunks, 2);
+        let tasks1 = initialize_tasks(0, number_of_chunks, 2).unwrap();
         let mut tasks1 = tasks1.iter();
-        let tasks2 = initialize_tasks(1, number_of_chunks, 2);
+        let tasks2 = initialize_tasks(1, number_of_chunks, 2).unwrap();
         let mut tasks2 = tasks2.iter();
         for _ in 0..number_of_chunks {
             assert_eq!(Some(next_round_height), state.current_round_height);
@@ -3913,7 +3913,7 @@ mod tests {
 
         // Process every chunk in the round as contributor 1.
         let number_of_chunks = environment.number_of_chunks();
-        let tasks1 = initialize_tasks(0, number_of_chunks, 2);
+        let tasks1 = initialize_tasks(0, number_of_chunks, 2).unwrap();
         let mut tasks1 = tasks1.iter();
         for _ in 0..number_of_chunks {
             assert_eq!(Some(next_round_height), state.current_round_height);
@@ -3967,7 +3967,7 @@ mod tests {
         }
 
         // Process every chunk in the round as contributor 2.
-        let tasks2 = initialize_tasks(1, number_of_chunks, 2);
+        let tasks2 = initialize_tasks(1, number_of_chunks, 2).unwrap();
         let mut tasks2 = tasks2.iter();
         for _ in 0..number_of_chunks {
             assert_eq!(Some(next_round_height), state.current_round_height);

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2444,8 +2444,6 @@ impl CoordinatorState {
             .iter()
             .chain(self.current_verifiers.clone().iter())
             .filter_map(|(participant, participant_info)| {
-                dbg!(participant);
-                dbg!(&participant_info.locked_chunks);
                 if !self.is_coordinator_contributor(&participant)
                     && participant_info
                         .locked_chunks

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -3084,6 +3084,9 @@ impl CoordinatorState {
 pub(crate) struct DropData {
     /// The participant being dropped.
     pub participant: Participant,
+    /// Determines the starting chunk, and subsequent tasks selected
+    /// for this participant. See [initialize_tasks] for more
+    /// information about this parameter.
     pub bucket_id: u64,
     /// Chunks currently locked by the participant.
     pub locked_chunks: Vec<u64>,

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2341,6 +2341,12 @@ impl CoordinatorState {
 
             // Check if the participant is still live and not a coordinator contributor.
             if elapsed.num_minutes() > contributor_timeout && !self.is_coordinator_contributor(&participant) {
+                tracing::info!(
+                    "Dropping participant {} because it has exceeded the maximum allowed time \
+                    ({} mins) since it was last seen by the coordinator.",
+                    participant,
+                    contributor_timeout
+                );
                 // Drop the participant.
                 justifications.push(self.drop_participant(participant)?);
             }

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -162,12 +162,21 @@ pub struct Environment {
     contributor_lock_chunk_limit: usize,
     /// The number of chunks a verifier is authorized to lock in tandem in a round.
     verifier_lock_chunk_limit: usize,
-    /// The number of minutes tolerated prior to assuming a contributor has dropped.
+    /// Returns the maximum duration a contributor can go without
+    /// being seen by the coordinator before it will be dropped from
+    /// the ceremony by the coordinator.
     #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    contributor_timeout: chrono::Duration,
-    /// The number of minutes tolerated prior to assuming a verifier has dropped.
+    contributor_seen_timeout: chrono::Duration,
+    /// The maximum duration a verifier can go without being seen by
+    /// the coordinator before it will be dropped from the ceremony by
+    /// the coordinator.
     #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    verifier_timeout: chrono::Duration,
+    verifier_seen_timeout: chrono::Duration,
+    /// The maximum duration a lock can be held by a participant
+    /// before it will be dropped from the ceremony by the
+    /// coordinator.
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    participant_lock_timeout: chrono::Duration,
     /// The number of drops tolerated by a participant before banning them from future rounds.
     participant_ban_threshold: u16,
     /// The setting to allow current contributors to join the queue for the next round.
@@ -284,19 +293,21 @@ impl Environment {
     }
 
     ///
-    /// Returns the number of minutes the coordinator tolerates
-    /// before assuming a contributor has disconnected.
+    /// Returns the maximum duration a contributor can go without
+    /// being seen by the coordinator before it will be dropped from
+    /// the ceremony by the coordinator.
     ///
-    pub const fn contributor_timeout(&self) -> chrono::Duration {
-        self.contributor_timeout
+    pub const fn contributor_seen_timeout(&self) -> chrono::Duration {
+        self.contributor_seen_timeout
     }
 
     ///
-    /// Returns the number of minutes the coordinator tolerates
-    /// before assuming a verifier has disconnected.
+    /// Returns the maximum duration a verifier can go without being
+    /// seen by the coordinator before it will be dropped from the
+    /// ceremony by the coordinator.
     ///
-    pub const fn verifier_timeout(&self) -> chrono::Duration {
-        self.verifier_timeout
+    pub const fn verifier_seen_timeout(&self) -> chrono::Duration {
+        self.verifier_seen_timeout
     }
 
     ///
@@ -492,7 +503,7 @@ impl Testing {
 
     pub fn contributor_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
         let mut deployment = self.clone();
-        deployment.environment.contributor_timeout = contributor_timeout;
+        deployment.environment.contributor_seen_timeout = contributor_timeout;
         deployment
     }
 }
@@ -528,8 +539,9 @@ impl std::default::Default for Testing {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_timeout: chrono::Duration::minutes(5),
-                verifier_timeout: chrono::Duration::minutes(15),
+                contributor_seen_timeout: chrono::Duration::minutes(5),
+                verifier_seen_timeout: chrono::Duration::minutes(15),
+                participant_lock_timeout: chrono::Duration::minutes(20),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -646,8 +658,9 @@ impl std::default::Default for Development {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_timeout: chrono::Duration::minutes(5),
-                verifier_timeout: chrono::Duration::minutes(15),
+                contributor_seen_timeout: chrono::Duration::minutes(5),
+                verifier_seen_timeout: chrono::Duration::minutes(15),
+                participant_lock_timeout: chrono::Duration::minutes(20),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -758,8 +771,9 @@ impl std::default::Default for Production {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_timeout: chrono::Duration::minutes(5),
-                verifier_timeout: chrono::Duration::minutes(15),
+                contributor_seen_timeout: chrono::Duration::minutes(5),
+                verifier_seen_timeout: chrono::Duration::minutes(15),
+                participant_lock_timeout: chrono::Duration::minutes(20),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: false,
                 allow_current_verifiers_in_queue: true,

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -138,7 +138,7 @@ impl Parameters {
     }
 }
 
-#[serde_as]
+#[serde_with::serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Environment {
     /// The parameter settings of this coordinator.

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -311,6 +311,15 @@ impl Environment {
     }
 
     ///
+    /// Returns the maximum duration that a participant can hold a
+    /// lock before being dropped from the ceremony by the
+    /// coordinator.
+    ///
+    pub const fn participant_lock_timeout(&self) -> chrono::Duration {
+        self.participant_lock_timeout
+    }
+
+    ///
     /// Returns the number of times the coordinator tolerates
     /// a dropped participant before banning them from future rounds.
     ///
@@ -501,9 +510,15 @@ impl Testing {
         deployment
     }
 
-    pub fn contributor_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.contributor_seen_timeout = contributor_timeout;
+        deployment
+    }
+
+    pub fn participant_lock_timeout(&self, participant_lock_timeout: chrono::Duration) -> Self {
+        let mut deployment = self.clone();
+        deployment.environment.participant_lock_timeout = participant_lock_timeout;
         deployment
     }
 }

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -1,3 +1,30 @@
+//! This library contains the backend logic for running a zero
+//! knowledge proof system setup ceremony, designed to generate a
+//! genesis block out of the contributions from many people. The
+//! theory is that the more contributors that participate from the
+//! general public, the less likely it is that every contributor is
+//! dishonest. It only takes one honest contributor to create a secure
+//! genesis block. This ceremony is different to previously run setup
+//! ceremonies in that it allows multiple contributors to contribute
+//! in parallel.
+//!
+//! The central piece of code of this library is the [Coordinator],
+//! which orchestrates the ceremony. The coordinator is created with a
+//! set of parameters specified in [environment::Environment], these
+//! parameters will differ between development, testing and production
+//! use cases.
+//!
+//! A ceremony consists of 3 different types of
+//! [objects::Participant]s. Regular contributors, replacement
+//! contributors (which wait in standby during a round to replace a
+//! contributor which is dropped), and verifiers which verify the
+//! submitted contributions as they arrive.
+//!
+//! See [objects::task::initialize_tasks] for an in depth explanation
+//! of how the [objects::task::Task]s for each participant in the
+//! ceremony are generated depending on the number of chunks and the
+//! number of participants in the round.
+
 #[macro_use]
 mod macros;
 

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -35,3 +35,6 @@ pub mod testing;
 
 #[cfg(test)]
 pub mod tests;
+
+#[macro_use]
+extern crate serde_with;

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -62,6 +62,3 @@ pub mod testing;
 
 #[cfg(test)]
 pub mod tests;
-
-#[macro_use]
-extern crate serde_with;

--- a/phase1-coordinator/src/objects/mod.rs
+++ b/phase1-coordinator/src/objects/mod.rs
@@ -12,3 +12,6 @@ pub use participant::*;
 
 pub mod round;
 pub use round::*;
+
+pub mod task;
+pub use task::Task;

--- a/phase1-coordinator/src/objects/participant.rs
+++ b/phase1-coordinator/src/objects/participant.rs
@@ -11,6 +11,8 @@ use std::fmt::{self};
 pub type ContributorId = String;
 pub type VerifierId = String;
 
+/// A participant in the setup ceremony. The participant can either be
+/// a [Participant::Contributor] or a [Participant::Verifier].
 #[derive(Clone, Eq, PartialEq, Hash, SerdeDiff)]
 pub enum Participant {
     Contributor(ContributorId),

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -580,6 +580,11 @@ impl Round {
                 let chunk = self.chunk(chunk_id)?;
                 // Fetch the current contribution ID.
                 let current_contribution_id = chunk.current_contribution_id();
+
+                if current_contribution_id == 0 {
+                    return Err(CoordinatorError::ChunkCannotLockZeroContributions { chunk_id });
+                }
+
                 // Fetch the previous contribution locator.
                 let challenge_locator =
                     Locator::ContributionFile(current_round_height, chunk_id, current_contribution_id - 1, true);

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -747,8 +747,8 @@ impl Round {
     ) -> Result<(), CoordinatorError> {
         // Check that the justification is valid for this operation, and fetch the necessary state.
         let (participant, locked_chunks) = match justification {
-            Justification::BanCurrent(participant, _, locked_chunks, _, _) => (participant, locked_chunks),
-            Justification::DropCurrent(participant, _, locked_chunks, _, _) => (participant, locked_chunks),
+            Justification::BanCurrent(data) => (&data.participant, &data.locked_chunks),
+            Justification::DropCurrent(data) => (&data.participant, &data.locked_chunks),
             _ => return Err(CoordinatorError::JustificationInvalid),
         };
 
@@ -852,8 +852,8 @@ impl Round {
     ) -> Result<(), CoordinatorError> {
         // Check that the justification is valid for this operation, and fetch the necessary state.
         let (participant, tasks) = match justification {
-            Justification::BanCurrent(participant, _, _, tasks, _) => (participant, tasks),
-            Justification::DropCurrent(participant, _, _, tasks, _) => (participant, tasks),
+            Justification::BanCurrent(data) => (&data.participant, &data.tasks),
+            Justification::DropCurrent(data) => (&data.participant, &data.tasks),
             _ => return Err(CoordinatorError::JustificationInvalid),
         };
 

--- a/phase1-coordinator/src/objects/task.rs
+++ b/phase1-coordinator/src/objects/task.rs
@@ -1,0 +1,190 @@
+use std::{collections::LinkedList, str::FromStr};
+
+use serde::{
+    de::{self, Error},
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
+
+/// The id of a task to be performed by a ceremony participant at a
+/// given contribution level, for a given chunk.
+///
+/// ```txt, ignore
+/// +----------------+---------+---------+---------+
+/// | ...            |  Task   |  Task   |  Task   |
+/// +----------------+---------+---------+---------+
+/// | Contribution 1 |  Task   |  Task   |  Task   |
+/// +----------------+---------+---------+---------+
+/// | Contribution 0 |  Task   |  Task   |  Task   |
+/// +----------------+---------+---------+---------+
+/// | Chunk          | Chunk 0 | Chunk 1 | ...     |
+/// +----------------+---------+---------+---------+
+/// ```
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct Task {
+    chunk_id: u64,
+    contribution_id: u64,
+}
+
+impl Task {
+    #[inline]
+    pub fn new(chunk_id: u64, contribution_id: u64) -> Self {
+        Self {
+            chunk_id,
+            contribution_id,
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, chunk_id: u64) -> bool {
+        self.chunk_id == chunk_id
+    }
+
+    #[inline]
+    pub fn chunk_id(&self) -> u64 {
+        self.chunk_id
+    }
+
+    #[inline]
+    pub fn contribution_id(&self) -> u64 {
+        self.contribution_id
+    }
+
+    #[inline]
+    pub fn to_tuple(&self) -> (u64, u64) {
+        (self.chunk_id, self.contribution_id)
+    }
+}
+
+impl Serialize for Task {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("{}/{}", self.chunk_id, self.contribution_id))
+    }
+}
+
+impl<'de> Deserialize<'de> for Task {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Task, D::Error> {
+        let s = String::deserialize(deserializer)?;
+
+        let mut task = s.split("/");
+        let chunk_id = task.next().ok_or(D::Error::custom("invalid chunk ID"))?;
+        let contribution_id = task.next().ok_or(D::Error::custom("invalid contribution ID"))?;
+        Ok(Task::new(
+            u64::from_str(&chunk_id).map_err(de::Error::custom)?,
+            u64::from_str(&contribution_id).map_err(de::Error::custom)?,
+        ))
+    }
+}
+
+pub fn initialize_tasks(
+    starting_bucket_id: u64, // 0-indexed
+    number_of_chunks: u64,
+    number_of_contributors: u64,
+) -> LinkedList<Task> {
+    let number_of_buckets = number_of_contributors;
+
+    // Fetch the bucket size.
+    let bucket_size = number_of_chunks / number_of_buckets as u64;
+
+    // It takes `number_of_contributors * bucket_size` to get to initial stable state.
+    // You will jump up (total_jumps - starting_bucket_id) times.
+    let number_of_initial_steps = (number_of_contributors - 1) - starting_bucket_id;
+    let number_of_final_steps = starting_bucket_id;
+    let mut initial_steps = 0;
+    let mut final_steps = 0;
+
+    // Compute the start and end indices.
+    let start = starting_bucket_id * bucket_size;
+    let end = start + number_of_chunks;
+
+    // Add the tasks in FIFO ordering.
+    let mut tasks = LinkedList::new();
+    tasks.push_back(Task::new(start % number_of_chunks, 1));
+
+    // Skip one from the start index and calculate the chunk ID and contribution ID to the end.
+    for current_index in start + 1..end {
+        let chunk_id = current_index % number_of_chunks;
+
+        // Check if this is a new bucket.
+        let is_new_bucket = (chunk_id % bucket_size) == 0;
+
+        // Check if we have initial steps to increment.
+        if is_new_bucket && initial_steps < number_of_initial_steps {
+            initial_steps += 1;
+        }
+
+        // Check if we have iterated past the modulus and are in final steps.
+        if is_new_bucket && current_index >= number_of_chunks {
+            // Check if we have final steps to increment.
+            if final_steps < number_of_final_steps {
+                final_steps += 1;
+            }
+        }
+
+        // Compute the contribution ID.
+        let steps = (initial_steps + final_steps) % number_of_contributors;
+        let contribution_id = steps + 1;
+
+        tasks.push_back(Task::new(chunk_id, contribution_id as u64));
+    }
+
+    tasks
+}
+
+#[cfg(test)]
+mod test {
+    use super::{initialize_tasks, Task};
+    use crate::testing::prelude::test_logger;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_task() {
+        let task = Task::new(0, 1);
+        assert_eq!("\"0/1\"", serde_json::to_string(&task).unwrap());
+        assert_eq!(task, serde_json::from_str("\"0/1\"").unwrap());
+    }
+
+    #[test]
+    fn test_initialize_tasks() {
+        let number_of_chunks = 3;
+        let number_of_contributors = 2;
+
+        let bucket_id = 0;
+        let mut tasks = initialize_tasks(bucket_id, number_of_chunks, number_of_contributors).into_iter();
+        assert_eq!(Some(Task::new(0, 1)), tasks.next());
+        assert_eq!(Some(Task::new(1, 2)), tasks.next());
+        assert_eq!(Some(Task::new(2, 2)), tasks.next());
+
+        let bucket_id = 1;
+        let mut tasks = initialize_tasks(bucket_id, number_of_chunks, number_of_contributors).into_iter();
+        assert_eq!(Some(Task::new(1, 1)), tasks.next());
+        assert_eq!(Some(Task::new(2, 1)), tasks.next());
+        assert_eq!(Some(Task::new(0, 2)), tasks.next());
+    }
+
+    #[test]
+    fn test_initialize_tasks_unique() {
+        test_logger();
+
+        fn test_uniqueness_of_tasks(number_of_chunks: u64, number_of_contributors: u64) {
+            let mut all_tasks = HashSet::new();
+            for bucket_id in 0..number_of_contributors {
+                // trace!("Contributor {}", bucket_id);
+                let mut tasks = initialize_tasks(bucket_id, number_of_chunks, number_of_contributors).into_iter();
+                while let Some(task) = tasks.next() {
+                    assert!(all_tasks.insert(task));
+                }
+            }
+        }
+
+        for number_of_contributors in 1..32 {
+            tracing::trace!("{} contributors", number_of_contributors,);
+            for number_of_chunks in number_of_contributors..256 {
+                test_uniqueness_of_tasks(number_of_chunks, number_of_contributors);
+            }
+        }
+    }
+}

--- a/phase1-coordinator/src/objects/task.rs
+++ b/phase1-coordinator/src/objects/task.rs
@@ -8,10 +8,16 @@ use serde::{
     Serializer,
 };
 
-/// The id of a task to be performed by a ceremony participant at a
-/// given contribution level, for a given chunk.
+/// The identity/position of a task to be performed by a ceremony
+/// participant at a given contribution level, for a given chunk.
+///
+/// Each contribution for a given task will be created by a unique
+/// contributor. The total number of contributions per task at the end
+/// of a successful round will be equal to the number of contributors
+/// in that round.
 ///
 /// ```txt, ignore
+///   Contribution ID
 /// +----------------+---------+---------+---------+
 /// | ...            |  Task   |  Task   |  Task   |
 /// +----------------+---------+---------+---------+
@@ -19,10 +25,9 @@ use serde::{
 /// +----------------+---------+---------+---------+
 /// | Contribution 0 |  Task   |  Task   |  Task   |
 /// +----------------+---------+---------+---------+
-/// | Chunk          | Chunk 0 | Chunk 1 | ...     |
-/// +----------------+---------+---------+---------+
+///                  | Chunk 0 | Chunk 1 | ...     | Chunk ID
+///                  +---------+---------+---------+
 /// ```
-///
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Task {
     chunk_id: u64,

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     authentication::Dummy,
     commands::{Seed, SigningKey, SEED_LENGTH},
-    environment::{Environment, Parameters, Testing},
+    environment::{Environment, Parameters, Settings, Testing},
     objects::Task,
     testing::prelude::*,
     Coordinator,
@@ -1578,7 +1578,7 @@ fn drop_contributor_and_reassign_tasks_test() -> anyhow::Result<()> {
 fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     let time = Arc::new(MockTimeSource::new(Utc::now()));
 
-    let parameters = Parameters::Custom((
+    let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
         CurveKind::Bls12_377,
@@ -1591,7 +1591,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
         .contributor_seen_timeout(chrono::Duration::minutes(5))
         .participant_lock_timeout(chrono::Duration::minutes(10));
 
-    let environment = initialize_test_environment_with_debug(&Environment::from(testing_deployment));
+    let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
     // Instantiate a coordinator.
     let coordinator = Coordinator::new_with_time(environment, Box::new(Dummy), time.clone())?;
@@ -1640,7 +1640,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     let time = Arc::new(MockTimeSource::new(Utc::now()));
 
-    let parameters = Parameters::Custom((
+    let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
         CurveKind::Bls12_377,
@@ -1648,12 +1648,11 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
         16, /* batch_size */
         16, /* chunk_size */
     ));
-
     let testing_deployment: Testing = Testing::from(parameters)
         .contributor_seen_timeout(chrono::Duration::minutes(5))
         .participant_lock_timeout(chrono::Duration::minutes(8));
 
-    let environment = initialize_test_environment_with_debug(&Environment::from(testing_deployment));
+    let environment = initialize_test_environment(&Environment::from(testing_deployment));
     let number_of_chunks = environment.number_of_chunks() as usize;
 
     // Instantiate a coordinator.
@@ -1716,7 +1715,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     let time = Arc::new(MockTimeSource::new(Utc::now()));
 
-    let parameters = Parameters::Custom((
+    let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
         ProvingSystem::Groth16,
         CurveKind::Bls12_377,
@@ -1729,7 +1728,7 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
         .contributor_seen_timeout(chrono::Duration::minutes(20))
         .participant_lock_timeout(chrono::Duration::minutes(10));
 
-    let environment = initialize_test_environment_with_debug(&Environment::from(testing_deployment));
+    let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
     // Instantiate a coordinator.
     let coordinator = Coordinator::new_with_time(environment, Box::new(Dummy), time.clone())?;

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
     authentication::Dummy,
     commands::{Seed, SigningKey, SEED_LENGTH},
-    coordinator_state::Task,
     environment::{Environment, Parameters, Testing},
+    objects::Task,
     testing::prelude::*,
     Coordinator,
     MockTimeSource,

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -227,25 +227,13 @@ impl Contribute {
         }
 
         let cloned = self.clone();
-        //TODO: this is broken, probably because there is some
-        // blocking code in one of the other tasks.
-        //
-        // let join_handle: JoinHandle<anyhow::Result<()>> = tokio::task::spawn(async move {
-        //     let auth_rng = &mut rand::rngs::OsRng;
-        //     loop {
-        //         println!("Performing heartbeat.");
-        //         tracing::info!("Performing heartbeat.");
-        //         cloned.heartbeat(auth_rng).await?;
-        //         delay_for(heartbeat_poll_duration).await;
-        //     }
-        // });
-        // futures.push(join_handle);
-
+        // NOTE: Attempted to use a task, however this did not work as
+        // epected. It seems likely there is some blocking code in one
+        // of the other tasks.
         std::thread::spawn(move || {
             let auth_rng = &mut rand::rngs::OsRng;
             let mut runtime = tokio::runtime::Runtime::new().unwrap();
             loop {
-                println!("Performing heartbeat.");
                 tracing::info!("Performing heartbeat.");
                 if let Err(error) = runtime.block_on(cloned.heartbeat(auth_rng)) {
                     tracing::error!("Error performing heartbeat: {}", error);

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -45,10 +45,7 @@ use std::{
     str::FromStr,
     sync::{Arc, RwLock},
 };
-use tokio::{
-    task::JoinHandle,
-    time::{delay_for, Instant},
-};
+use tokio::time::{delay_for, Instant};
 use tracing::{debug, error, info, warn};
 use url::Url;
 
@@ -60,7 +57,7 @@ const RESPONSE_HASH_FILENAME: &str = "response.hash";
 const DELAY_AFTER_ERROR_DURATION_SECS: i64 = 60;
 const DELAY_WAIT_FOR_PIPELINE_SECS: i64 = 5;
 const DELAY_POLL_CEREMONY_SECS: i64 = 5;
-const HEARTBEAT_POLL_SECS: i64 = 10;
+const HEARTBEAT_POLL_SECS: i64 = 30;
 
 lazy_static! {
     static ref PIPELINE: RwLock<HashMap<PipelineLane, VecDeque<LockResponse>>> = {


### PR DESCRIPTION
Fix for #234 

+ Refactor timeouts to use `chrono::Duration` (I initially did this to play around with timeouts in seconds, but decided the refactor was probably worth keeping)
+ Refactor `Coordinator` and `CoordinatorState` so that their time dependency is able to be mocked.
+ Add test for contributor timeout.
+ Refactoring `phase1-contributor`'s `contribute` module to reduce code duplication, better documentation, and a unit test.
+ Make some methods for `Chunk` public to allow them to be used for testing in other crates, and make the argument names a little easier to read (`verifier` and `contributor` instead of `participant` to help indicate which type of participant they are expecting. Ideally in the future we will have #245 to make this unnecessary).
+ Refactor `Task` and `initialize_tasks()` to their own `task` module.
+ Add error cases for `initialize_tasks()` for invalid input, and add more unit tests for it.
+ Documentation for the `Justification` enum, and refactoring the enum data into a new `DropData` struct so that the fields are named and easier to read.
+ More documentation for `phase1-coordinator` in various places.
+ Refactor `CoordinatorState::locked_chunks` to use a new `ChunkLock` struct which also records the lock time.
+ Add a new type of drop for when participants hold locks for too long.