### PR TITLE
Refactor storage::Locator enum to reduce use of un-named tuple fypes/fields/variants

### DIFF
--- a/phase1-coordinator/src/commands/computation.rs
+++ b/phase1-coordinator/src/commands/computation.rs
@@ -47,9 +47,11 @@ impl Computation {
 
         // Fetch the chunk ID from the response locator.
         let (round_height, chunk_id, contribution_id) = match response_locator {
-            Locator::ContributionFile(round_height, chunk_id, contribution_id, _) => {
-                (*round_height, *chunk_id as usize, *contribution_id)
-            }
+            Locator::ContributionFile(contribution_locator) => (
+                contribution_locator.round_height,
+                contribution_locator.chunk_id as usize,
+                contribution_locator.contribution_id,
+            ),
             _ => return Err(CoordinatorError::ContributionLocatorIncorrect.into()),
         };
 
@@ -172,7 +174,7 @@ mod tests {
     use crate::{
         authentication::{Dummy, Signature},
         commands::{Computation, Initialization, Seed, SEED_LENGTH},
-        storage::{Locator, Object, StorageLock},
+        storage::{ContributionLocator, Locator, Object, StorageLock},
         testing::prelude::*,
     };
     use setup_utils::calculate_hash;
@@ -211,12 +213,14 @@ mod tests {
             trace!("Running computation on test chunk {}", chunk_id);
 
             // Fetch the challenge locator.
-            let challenge_locator = &Locator::ContributionFile(round_height, chunk_id, 0, true);
+            let challenge_locator =
+                &Locator::ContributionFile(ContributionLocator::new(round_height, chunk_id, 0, true));
             // Fetch the response locator.
-            let response_locator = &Locator::ContributionFile(round_height, chunk_id, 1, false);
+            let response_locator =
+                &Locator::ContributionFile(ContributionLocator::new(round_height, chunk_id, 1, false));
             // Fetch the contribution file signature locator.
             let contribution_file_signature_locator =
-                &Locator::ContributionFileSignature(round_height, chunk_id, 1, false);
+                &Locator::ContributionFileSignature(ContributionLocator::new(round_height, chunk_id, 1, false));
 
             if !storage.exists(response_locator) {
                 let expected_filesize = Object::contribution_file_size(&TEST_ENVIRONMENT_3, chunk_id, false);

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -2,7 +2,7 @@ use crate::{
     authentication::Signature,
     commands::SigningKey,
     environment::Environment,
-    storage::{Locator, Object, StorageLock},
+    storage::{ContributionLocator, Locator, Object, StorageLock},
     CoordinatorError,
 };
 use phase1::{helpers::CurveKind, Phase1, Phase1Parameters, PublicKey};
@@ -48,16 +48,36 @@ impl Verification {
         }
 
         // Fetch the locators for `Verification`.
-        let challenge_locator = Locator::ContributionFile(round_height, chunk_id, current_contribution_id - 1, true);
-        let response_locator = Locator::ContributionFile(round_height, chunk_id, current_contribution_id, false);
+        let challenge_locator = Locator::ContributionFile(ContributionLocator::new(
+            round_height,
+            chunk_id,
+            current_contribution_id - 1,
+            true,
+        ));
+        let response_locator = Locator::ContributionFile(ContributionLocator::new(
+            round_height,
+            chunk_id,
+            current_contribution_id,
+            false,
+        ));
         let (next_challenge_locator, contribution_file_signature_locator) = match is_final_contribution {
             true => (
-                Locator::ContributionFile(round_height + 1, chunk_id, 0, true),
-                Locator::ContributionFileSignature(round_height + 1, chunk_id, 0, true),
+                Locator::ContributionFile(ContributionLocator::new(round_height + 1, chunk_id, 0, true)),
+                Locator::ContributionFileSignature(ContributionLocator::new(round_height + 1, chunk_id, 0, true)),
             ),
             false => (
-                Locator::ContributionFile(round_height, chunk_id, current_contribution_id, true),
-                Locator::ContributionFileSignature(round_height, chunk_id, current_contribution_id, true),
+                Locator::ContributionFile(ContributionLocator::new(
+                    round_height,
+                    chunk_id,
+                    current_contribution_id,
+                    true,
+                )),
+                Locator::ContributionFileSignature(ContributionLocator::new(
+                    round_height,
+                    chunk_id,
+                    current_contribution_id,
+                    true,
+                )),
             ),
         };
 
@@ -314,7 +334,7 @@ mod tests {
     use crate::{
         authentication::Dummy,
         commands::{Computation, Seed, Verification, SEED_LENGTH},
-        storage::{Locator, Object, StorageLock},
+        storage::{ContributionLocator, Locator, Object, StorageLock},
         testing::prelude::*,
         Coordinator,
     };
@@ -369,12 +389,14 @@ mod tests {
 
         for chunk_id in 0..number_of_chunks {
             // Fetch the challenge locator.
-            let challenge_locator = &Locator::ContributionFile(round_height, chunk_id, 0, true);
+            let challenge_locator =
+                &Locator::ContributionFile(ContributionLocator::new(round_height, chunk_id, 0, true));
             // Fetch the response locator.
-            let response_locator = &Locator::ContributionFile(round_height, chunk_id, 1, false);
+            let response_locator =
+                &Locator::ContributionFile(ContributionLocator::new(round_height, chunk_id, 1, false));
             // Fetch the contribution file signature locator.
             let contribution_file_signature_locator =
-                &Locator::ContributionFileSignature(round_height, chunk_id, 1, false);
+                &Locator::ContributionFileSignature(ContributionLocator::new(round_height, chunk_id, 1, false));
 
             if !storage.exists(response_locator) {
                 let expected_filesize = Object::contribution_file_size(&TEST_ENVIRONMENT_3, chunk_id, false);
@@ -417,8 +439,8 @@ mod tests {
 
             // Fetch the next contribution locator.
             let next = match is_final {
-                true => Locator::ContributionFile(round_height + 1, chunk_id, 0, true),
-                false => Locator::ContributionFile(round_height, chunk_id, 1, true),
+                true => Locator::ContributionFile(ContributionLocator::new(round_height + 1, chunk_id, 0, true)),
+                false => Locator::ContributionFile(ContributionLocator::new(round_height, chunk_id, 1, true)),
             };
 
             // Check the next challenge file exists.

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -14,16 +14,34 @@ use std::{
 };
 use zexe_algebra::{Bls12_377, BW6_761};
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ContributionLocator {
+    pub round_height: u64,
+    pub chunk_id: u64,
+    pub contribution_id: u64,
+    pub is_verified: bool,
+}
+
+impl ContributionLocator {
+    pub fn new(round_height: u64, chunk_id: u64, contribution_id: u64, is_verified: bool) -> Self {
+        Self {
+            round_height,
+            chunk_id,
+            contribution_id,
+            is_verified,
+        }
+    }
+}
+
 /// A data structure representing all possible types of keys in storage.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Locator {
     CoordinatorState,
     RoundHeight,
-    RoundState(u64),
-    RoundFile(u64),
-    /// (round_height, chunk_id, contribution_id, is_verified)
-    ContributionFile(u64, u64, u64, bool),
-    ContributionFileSignature(u64, u64, u64, bool),
+    RoundState { round_height: u64 },
+    RoundFile { round_height: u64 },
+    ContributionFile(ContributionLocator),
+    ContributionFileSignature(ContributionLocator),
 }
 
 /// A data structure representing all possible types of values in storage.


### PR DESCRIPTION
refactor the `storage::Locator` enum to increase code readability