### PR TITLE
Don't initialize the logger

### DIFF
--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -378,9 +378,6 @@ impl Coordinator {
     ///
     #[inline]
     pub fn initialize(&self) -> Result<(), CoordinatorError> {
-        #[cfg(not(test))]
-        initialize_logger(&self.environment);
-
         // Check if the deployment is in production, that the signature scheme is secure.
         if *self.environment.deployment() == Deployment::Production && !self.signature.is_secure() {
             return Err(CoordinatorError::SignatureSchemeIsInsecure);


### PR DESCRIPTION
This PR removes the logger initialisation from the Operator initialize method. The motivation is to let the users of this library to set their own loggers. In particular, it will allow to filter away the logs from third party libraries such as hyper.