### PR TITLE
Storage locator path refactor

### DIFF
--- a/phase1-coordinator/src/objects/chunk.rs
+++ b/phase1-coordinator/src/objects/chunk.rs
@@ -1,5 +1,6 @@
 use crate::{
     objects::{participant::*, Contribution},
+    storage::LocatorPath,
     CoordinatorError,
 };
 
@@ -40,8 +41,8 @@ impl Chunk {
     pub fn new(
         chunk_id: u64,
         participant: Participant,
-        verifier_locator: String,
-        verifier_signature_locator: String,
+        verifier_locator: LocatorPath,
+        verifier_signature_locator: LocatorPath,
     ) -> Result<Self, CoordinatorError> {
         match participant.is_verifier() {
             // Construct the starting contribution template for this chunk.
@@ -364,8 +365,8 @@ impl Chunk {
         &mut self,
         contribution_id: u64,
         contributor: &Participant,
-        contributed_locator: String,
-        contributed_signature_locator: String,
+        contributed_locator: LocatorPath,
+        contributed_signature_locator: LocatorPath,
     ) -> Result<(), CoordinatorError> {
         // Check that the participant is a contributor.
         if !contributor.is_contributor() {
@@ -410,8 +411,8 @@ impl Chunk {
         &mut self,
         contribution_id: u64,
         verifier: Participant,
-        verified_locator: String,
-        verified_signature_locator: String,
+        verified_locator: LocatorPath,
+        verified_signature_locator: LocatorPath,
     ) -> Result<(), CoordinatorError> {
         // Check that the participant is a verifier.
         if !verifier.is_verifier() {

--- a/phase1-coordinator/src/objects/contribution.rs
+++ b/phase1-coordinator/src/objects/contribution.rs
@@ -1,4 +1,4 @@
-use crate::{objects::Participant, CoordinatorError};
+use crate::{objects::Participant, storage::LocatorPath, CoordinatorError};
 
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -8,14 +8,14 @@ use tracing::trace;
 pub struct Contribution {
     contributor_id: Option<Participant>,
     #[serde(rename = "contributedLocation")]
-    contributed_locator: Option<String>,
+    contributed_locator: Option<LocatorPath>,
     #[serde(rename = "contributedSignatureLocation")]
-    contributed_signature_locator: Option<String>,
+    contributed_signature_locator: Option<LocatorPath>,
     verifier_id: Option<Participant>,
     #[serde(rename = "verifiedLocation")]
-    verified_locator: Option<String>,
+    verified_locator: Option<LocatorPath>,
     #[serde(rename = "verifiedSignatureLocation")]
-    verified_signature_locator: Option<String>,
+    verified_signature_locator: Option<LocatorPath>,
     verified: bool,
 }
 
@@ -37,14 +37,14 @@ impl Contribution {
     /// Returns a reference to the contributor locator, if it exists.
     /// Otherwise returns `None`.
     #[inline]
-    pub fn get_contributed_location(&self) -> &Option<String> {
+    pub fn get_contributed_location(&self) -> &Option<LocatorPath> {
         &self.contributed_locator
     }
 
     /// Returns a reference to the contributor signature locator, if it exists.
     /// Otherwise returns `None`.
     #[inline]
-    pub fn get_contributed_signature_location(&self) -> &Option<String> {
+    pub fn get_contributed_signature_location(&self) -> &Option<LocatorPath> {
         &self.contributed_signature_locator
     }
 
@@ -59,14 +59,14 @@ impl Contribution {
     /// Returns a reference to the verifier locator, if it exists.
     /// Otherwise returns `None`.
     #[inline]
-    pub fn get_verified_location(&self) -> &Option<String> {
+    pub fn get_verified_location(&self) -> &Option<LocatorPath> {
         &self.verified_locator
     }
 
     /// Returns a reference to the verifier signature locator, if it exists.
     /// Otherwise returns `None`.
     #[inline]
-    pub fn get_verified_signature_location(&self) -> &Option<String> {
+    pub fn get_verified_signature_location(&self) -> &Option<LocatorPath> {
         &self.verified_signature_locator
     }
 
@@ -81,8 +81,8 @@ impl Contribution {
     #[inline]
     pub(crate) fn new_contributor(
         participant: Participant,
-        contributed_locator: String,
-        contributed_signature_locator: String,
+        contributed_locator: LocatorPath,
+        contributed_signature_locator: LocatorPath,
     ) -> Result<Self, CoordinatorError> {
         // Check that the participant is a contributor.
         if !participant.is_contributor() {
@@ -112,8 +112,8 @@ impl Contribution {
     pub(crate) fn new_verifier(
         contribution_id: u64,
         participant: Participant,
-        verified_locator: String,
-        verified_signature_locator: String,
+        verified_locator: LocatorPath,
+        verified_signature_locator: LocatorPath,
     ) -> Result<Self, CoordinatorError> {
         // Check that the participant is a verifier.
         if !participant.is_verifier() {
@@ -157,8 +157,8 @@ impl Contribution {
     pub(crate) fn assign_verifier(
         &mut self,
         participant: Participant,
-        verified_locator: String,
-        verified_signature_locator: String,
+        verified_locator: LocatorPath,
+        verified_signature_locator: LocatorPath,
     ) -> Result<(), CoordinatorError> {
         // Check that the participant is a verifier.
         if !participant.is_verifier() {

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -312,20 +312,6 @@ impl TryFrom<&Path> for LocatorPath {
     }
 }
 
-#[derive(Clone)]
-pub struct RemoveFileAction {
-    path: LocatorPath,
-}
-
-impl RemoveFileAction {
-    pub fn new(path: LocatorPath) -> Self {
-        Self { path }
-    }
-}
-pub enum StorageAction {
-    RemoveFile(RemoveFileAction),
-}
-
 pub trait StorageLocator {
     /// Returns a locator path corresponding to the given locator.
     fn to_path(&self, locator: &Locator) -> Result<LocatorPath, CoordinatorError>;

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -19,7 +19,6 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
     collections::{HashSet, LinkedList},
     iter::FromIterator,
-    path::Path,
     sync::Arc,
 };
 
@@ -1402,7 +1401,7 @@ fn check_round_matches_storage_files(storage: &dyn Storage, round: &Round) {
             );
             continue;
         };
-        let path = Path::new(&initial_challenge_location);
+        let path = initial_challenge_location.as_path();
         let chunk_dir = path.parent().unwrap();
 
         let n_files = std::fs::read_dir(&chunk_dir).unwrap().count();

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -974,27 +974,27 @@ mod test {
             "aleo1h7pwa3dh2egahqj7yvq7f7e533lr0ueysaxde2ktmtu2pxdjvqfqsj607a.contributor".to_string(),
         );
 
-        let mut chunk = Chunk::new(0, verifier.clone(), String::new(), String::new()).unwrap();
+        let mut chunk = Chunk::new(0, verifier.clone(), String::new().into(), String::new().into()).unwrap();
 
         chunk.acquire_lock(contributor1.clone(), 3).unwrap();
         chunk
-            .add_contribution(1, &contributor1, String::new(), String::new())
+            .add_contribution(1, &contributor1, String::new().into(), String::new().into())
             .unwrap();
         assert!(!chunk_all_verified(&chunk));
         chunk.acquire_lock(verifier.clone(), 3).unwrap();
         chunk
-            .verify_contribution(1, verifier.clone(), String::new(), String::new())
+            .verify_contribution(1, verifier.clone(), String::new().into(), String::new().into())
             .unwrap();
         assert!(chunk_all_verified(&chunk));
 
         chunk.acquire_lock(contributor2.clone(), 3).unwrap();
         chunk
-            .add_contribution(2, &contributor2, String::new(), String::new())
+            .add_contribution(2, &contributor2, String::new().into(), String::new().into())
             .unwrap();
         assert!(!chunk_all_verified(&chunk));
         chunk.acquire_lock(verifier.clone(), 3).unwrap();
         chunk
-            .verify_contribution(2, verifier.clone(), String::new(), String::new())
+            .verify_contribution(2, verifier.clone(), String::new().into(), String::new().into())
             .unwrap();
         assert!(chunk_all_verified(&chunk));
 


### PR DESCRIPTION
Make use of storage locator paths more type safe with the use of a new LocatorPath wrapper type. In the future I'd like to reduce the use of this type in favour of `Locator` wherever possible, but for now this makes it much easier to keep track of it.