### PR TITLE
Updates for bandwidth measurements in reliability score check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tokio 1.7.0",
 ]
 
 [[package]]

--- a/setup1-contributor/src/reliability/bandwidth.rs
+++ b/setup1-contributor/src/reliability/bandwidth.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use anyhow::{anyhow, Result};
 use futures::{Sink, SinkExt};
-use setup1_shared::reliability::ContributorMessage;
+use setup1_shared::reliability::{ContributorMessage, ContributorMessageName};
 use tokio_tungstenite::tungstenite::protocol::Message;
 
 pub(super) async fn check<W>(write_half: &mut W, data: Vec<u8>) -> Result<()>
@@ -10,8 +10,11 @@ where
     W: Sink<Message> + Unpin,
     W::Error: Debug,
 {
-    let challenge = ContributorMessage::BandwidthChallenge(data);
-    let response = Message::binary(challenge.encode()?);
+    let challenge = ContributorMessage {
+        name: ContributorMessageName::BandwidthChallenge,
+        data,
+    };
+    let response = Message::binary(challenge.to_vec());
     write_half.send(response).await.map_err(|e| anyhow!("{:?}", e))?;
     Ok(())
 }

--- a/setup1-contributor/src/reliability/cpu.rs
+++ b/setup1-contributor/src/reliability/cpu.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use anyhow::{anyhow, Result};
 use futures::{Sink, SinkExt};
-use setup1_shared::reliability::ContributorMessage;
+use setup1_shared::reliability::{ContributorMessage, ContributorMessageName};
 use tokio_tungstenite::tungstenite::protocol::Message;
 
 fn calculate_powers_of_tau(input: Vec<u8>) -> Vec<u8> {
@@ -16,8 +16,11 @@ where
     W::Error: Debug,
 {
     let calculated = calculate_powers_of_tau(data);
-    let challenge = ContributorMessage::CpuChallenge(calculated);
-    let response = Message::binary(challenge.encode()?);
+    let challenge = ContributorMessage {
+        name: ContributorMessageName::CpuChallenge,
+        data: calculated,
+    };
+    let response = Message::binary(challenge.to_vec());
     write_half.send(response).await.map_err(|e| anyhow!("{:?}", e))?;
     Ok(())
 }

--- a/setup1-contributor/src/reliability/latency.rs
+++ b/setup1-contributor/src/reliability/latency.rs
@@ -2,16 +2,19 @@ use std::fmt::Debug;
 
 use anyhow::{anyhow, Result};
 use futures::{Sink, SinkExt};
-use setup1_shared::reliability::ContributorMessage;
+use setup1_shared::reliability::{ContributorMessage, ContributorMessageName};
 use tokio_tungstenite::tungstenite::protocol::Message;
 
-pub(super) async fn check<W>(write_half: &mut W, request_id: i64) -> Result<()>
+pub(super) async fn check<W>(write_half: &mut W, data: Vec<u8>) -> Result<()>
 where
     W: Sink<Message> + Unpin,
     W::Error: Debug,
 {
-    let pong = ContributorMessage::Pong { id: request_id };
-    let response = Message::binary(pong.encode()?);
+    let pong = ContributorMessage {
+        name: ContributorMessageName::Pong,
+        data,
+    };
+    let response = Message::binary(pong.to_vec());
     write_half.send(response).await.map_err(|e| anyhow!("{:?}", e))?;
     Ok(())
 }

--- a/setup1-shared/Cargo.toml
+++ b/setup1-shared/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 authors = ["The Aleo Team <hello@aleo.org>"]
 edition = "2018"
 
+[features]
+default = []
+async_message = ["tokio"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.7", features = ["io-util"] }
+tokio = { version = "1.7", features = ["io-util"], optional = true }

--- a/setup1-shared/Cargo.toml
+++ b/setup1-shared/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1.7", features = ["io-util"] }

--- a/setup1-shared/src/reliability/contributor.rs
+++ b/setup1-shared/src/reliability/contributor.rs
@@ -1,37 +1,33 @@
-use std::fmt::{self, Display};
+use super::message::MessageName;
 
-use serde::{Deserialize, Serialize};
-
-/// Message from contributor to coordinator
-#[derive(Debug, Deserialize, Serialize)]
-pub enum ContributorMessage {
-    BandwidthChallenge(Vec<u8>),
-    CpuChallenge(Vec<u8>),
-    Error(String),
-    Pong { id: i64 },
+#[derive(Debug, PartialEq)]
+pub enum ContributorMessageName {
+    BandwidthChallenge,
+    CpuChallenge,
+    Error,
+    Pong,
 }
 
-impl ContributorMessage {
-    /// Encodes self as a JSON message to a vector of bytes
-    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
-        serde_json::to_vec(self)
-    }
-
-    /// Decodes a JSON message from a slice of bytes into Self
-    pub fn decode(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-        serde_json::from_slice(bytes)
-    }
-}
-
-impl Display for ContributorMessage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ContributorMessage::*;
-        let text = match self {
-            BandwidthChallenge(_) => "BandwidthChallenge(Vec<u8>)".to_owned(),
-            CpuChallenge(_) => "CpuChallenge(Vec<u8>)".to_owned(),
-            Error(message) => format!("Error({})", message),
-            Pong { id } => format!("Pong {{ id: {} }}", id),
+impl MessageName for ContributorMessageName {
+    fn from_str(input: &str) -> Result<Self, String> {
+        use ContributorMessageName::*;
+        let name = match input {
+            "bandwidth_challenge" => BandwidthChallenge,
+            "cpu_challenge" => CpuChallenge,
+            "error" => Error,
+            "pong" => Pong,
+            _ => return Err(format!("Unknown ContributorMessageName: {}", input)),
         };
-        write!(f, "{}", text)
+        Ok(name)
+    }
+
+    fn as_bytes(&self) -> &'static [u8] {
+        use ContributorMessageName::*;
+        match self {
+            BandwidthChallenge => b"bandwidth_challenge",
+            CpuChallenge => b"cpu_challenge",
+            Error => b"error",
+            Pong => b"pong",
+        }
     }
 }

--- a/setup1-shared/src/reliability/coordinator.rs
+++ b/setup1-shared/src/reliability/coordinator.rs
@@ -1,37 +1,33 @@
-use std::fmt::{self, Display};
+use super::message::MessageName;
 
-use serde::{Deserialize, Serialize};
-
-/// Message from coordinator to contributor
-#[derive(Debug, Deserialize, Serialize)]
-pub enum CoordinatorMessage {
-    BandwidthChallenge(Vec<u8>),
-    CpuChallenge(Vec<u8>),
-    Error(String),
-    Ping { id: i64 },
+#[derive(Debug, PartialEq)]
+pub enum CoordinatorMessageName {
+    BandwidthChallenge,
+    CpuChallenge,
+    Error,
+    Ping,
 }
 
-impl CoordinatorMessage {
-    /// Encodes self as a JSON message to a vector of bytes
-    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
-        serde_json::to_vec(self)
-    }
-
-    /// Decodes a JSON message from a slice of bytes into Self
-    pub fn decode(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-        serde_json::from_slice(bytes)
-    }
-}
-
-impl Display for CoordinatorMessage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use CoordinatorMessage::*;
-        let text = match self {
-            BandwidthChallenge(_) => "BandwidthChallenge(Vec<u8>)".to_owned(),
-            CpuChallenge(_) => "CpuChallenge(Vec<u8>)".to_owned(),
-            Error(message) => format!("Error({})", message),
-            Ping { id } => format!("Ping {{ id: {} }}", id),
+impl MessageName for CoordinatorMessageName {
+    fn from_str(input: &str) -> Result<Self, String> {
+        use CoordinatorMessageName::*;
+        let name = match input {
+            "bandwidth_challenge" => BandwidthChallenge,
+            "cpu_challenge" => CpuChallenge,
+            "error" => Error,
+            "ping" => Ping,
+            _ => return Err(format!("Unknown CoordinatorMessageName: {}", input)),
         };
-        write!(f, "{}", text)
+        Ok(name)
+    }
+
+    fn as_bytes(&self) -> &'static [u8] {
+        use CoordinatorMessageName::*;
+        match self {
+            BandwidthChallenge => b"bandwidth_challenge",
+            CpuChallenge => b"cpu_challenge",
+            Error => b"error",
+            Ping => b"ping",
+        }
     }
 }

--- a/setup1-shared/src/reliability/message.rs
+++ b/setup1-shared/src/reliability/message.rs
@@ -1,0 +1,126 @@
+use std::io::{BufReader, Read};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+
+pub const MAXIMUM_MESSAGE_SIZE: usize = 101 * 1024 * 1024; // 101 Mb
+
+pub trait MessageName: Sized {
+    fn from_str(input: &str) -> Result<Self, String>;
+    fn as_bytes(&self) -> &'static [u8];
+}
+
+pub struct Message<T: MessageName> {
+    pub name: T,
+    pub data: Vec<u8>,
+}
+
+/// Message format:
+/// 1 byte name length | name | 4 bytes data length | data
+impl<T: MessageName> Message<T> {
+    /// Read message name as Vec of bytes
+    pub async fn read_name<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, Error> {
+        let mut name_length_buffer = [0u8; 1];
+        reader.read_exact(&mut name_length_buffer).await?;
+        let name_length = u8::from_be_bytes(name_length_buffer);
+        let mut name = vec![0; name_length as usize];
+        reader.read_exact(&mut name).await?;
+        Ok(name)
+    }
+
+    /// Read message data as Vec of bytes
+    pub async fn read_data<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, Error> {
+        let mut data_length_buffer = [0u8; 4];
+        reader.read_exact(&mut data_length_buffer).await?;
+        let data_length = u32::from_be_bytes(data_length_buffer) as usize;
+        if data_length > MAXIMUM_MESSAGE_SIZE {
+            return Err(format!(
+                "Message length exceeds the limit: {} vs {}",
+                data_length, MAXIMUM_MESSAGE_SIZE,
+            )
+            .into());
+        }
+        let mut data = vec![0; data_length];
+        reader.read_exact(&mut data).await?;
+        Ok(data)
+    }
+
+    /// Write entire message to a provided writer
+    pub async fn write<W: AsyncWrite + Unpin>(&self, writer: &mut W) -> Result<(), Error> {
+        self.write_name(writer).await?;
+        self.write_data(writer).await?;
+        Ok(())
+    }
+
+    /// Write only message name to a provided writer
+    pub async fn write_name<W: AsyncWrite + Unpin>(&self, writer: &mut W) -> Result<(), Error> {
+        let name = self.name.as_bytes();
+        let name_length = (name.len() as u8).to_be_bytes();
+        writer.write(&name_length).await?;
+        writer.write(name).await?;
+        Ok(())
+    }
+
+    /// Write only message name to a provided writer
+    pub async fn write_data<W: AsyncWrite + Unpin>(&self, writer: &mut W) -> Result<(), Error> {
+        let data_length = (self.data.len() as u32).to_be_bytes();
+        writer.write(&data_length).await?;
+        writer.write(&self.data).await?;
+        Ok(())
+    }
+
+    /// Encodes self as a vector of bytes
+    pub fn to_vec(&self) -> Vec<u8> {
+        let name = self.name.as_bytes();
+        let name_length = (name.len() as u8).to_be_bytes();
+        let data_length = (self.data.len() as u32).to_be_bytes();
+        [&name_length, name, &data_length, &self.data].concat()
+    }
+
+    /// Decodes Self from a slice of bytes
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, Error> {
+        let mut reader = BufReader::new(bytes);
+
+        let mut name_length_buffer = [0u8; 1];
+        reader.read_exact(&mut name_length_buffer)?;
+        let name_length = u8::from_be_bytes(name_length_buffer);
+        let mut name = vec![0; name_length as usize];
+        reader.read_exact(&mut name)?;
+
+        let mut data_length_buffer = [0u8; 4];
+        reader.read_exact(&mut data_length_buffer)?;
+        let data_length = u32::from_be_bytes(data_length_buffer) as usize;
+        if data_length > MAXIMUM_MESSAGE_SIZE {
+            return Err(format!(
+                "Message length exceeds the limit: {} vs {}",
+                data_length, MAXIMUM_MESSAGE_SIZE,
+            )
+            .into());
+        }
+        let mut data = vec![0; data_length as usize];
+        reader.read_exact(&mut data)?;
+
+        let name_string = String::from_utf8(name)?;
+
+        Ok(Self {
+            name: T::from_str(&name_string)?,
+            data,
+        })
+    }
+}
+
+#[cfg(test)]
+use super::ContributorMessageName;
+
+#[test]
+fn message_round_trip() {
+    let message = Message {
+        name: ContributorMessageName::CpuChallenge,
+        data: vec![1, 2, 3],
+    };
+    let encoded = message.to_vec();
+    let decoded = Message::<ContributorMessageName>::from_slice(&encoded).unwrap();
+    assert_eq!(decoded.name, message.name);
+    assert_eq!(decoded.data, message.data);
+}

--- a/setup1-shared/src/reliability/mod.rs
+++ b/setup1-shared/src/reliability/mod.rs
@@ -2,6 +2,12 @@
 
 mod contributor;
 mod coordinator;
+mod message;
 
-pub use contributor::ContributorMessage;
-pub use coordinator::CoordinatorMessage;
+pub use contributor::ContributorMessageName;
+pub use coordinator::CoordinatorMessageName;
+use message::Message;
+pub use message::{MessageName, MAXIMUM_MESSAGE_SIZE};
+
+pub type ContributorMessage = Message<ContributorMessageName>;
+pub type CoordinatorMessage = Message<CoordinatorMessageName>;


### PR DESCRIPTION
- Updated message structure in reliability checks to avoid extra copy when sending message from coordinator. It was possible to achieve by replacing enum with a structure containing two fields. First - `name` is an enum, second one - `data` is a vector of bytes. It allows to access `message.data` without matching on the whole message.
- Implemented manual message encoding/decoding instead of using serde. The reason was the huge overhead from the formats. For example, if serialize a structure containing 100Mb of data using MessagePack, the encoded size will be around 150Mb (and way more with JSON), which is not very convenient for measuring bandwidth. After this change the overhead is 20-30 bytes, because message format is the following:
`message name length (1 byte) | message name (256 bytes at most, usually 10-20) | data length (4 bytes) | data`
- updated WebSocket configuration to handle messages up to 100Mb