### PR TITLE
Drop participants which send heartbeats, but for some reason, can not accept work

### DIFF
--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -82,7 +82,7 @@ pub struct ParticipantInfo {
     dropped_at: Option<DateTime<Utc>>,
     /// A map of chunk IDs to locks on chunks that this participant currently holds.
     locked_chunks: HashMap<u64, ChunkLock>,
-    /// The timestamp when this participant last released a lock.
+    /// The timestamp when this participant last was released a lock.
     last_released: Option<DateTime<Utc>>,
     /// The list of (chunk ID, contribution ID) tasks that this participant is assigned to compute.
     assigned_tasks: LinkedList<Task>,
@@ -2834,6 +2834,7 @@ impl CoordinatorState {
 
                 if elapsed > participant_acceptance_timeout
                     && participant_info.locked_chunks.is_empty()
+                    && !participant_info.assigned_tasks.is_empty()
                     && !self.is_coordinator_contributor(&participant)
                 {
                     tracing::info!(

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2829,14 +2829,16 @@ impl CoordinatorState {
             .filter_map(|(participant, participant_info)| {
                 // Ensure we get the proper elapsed time since the last task was assigned.
                 // If no tasks have been assigned yet, we measure from the starting time.
-                if partcipant.last_released.is_none() {
-                    return None;
-                }
+                let last_seen = if participant_info.last_released.is_none() {
+                    participant_info.first_seen
+                } else {
+                    participant_info.last_released.unwrap()
+                };
 
-                let elapsed = now - participant.last_released.unwrap();
+                let elapsed = now - last_seen;
 
                 if elapsed > participant_acceptance_timeout
-                    && participant.locked_chunks.is_empty()
+                    && participant_info.locked_chunks.is_empty()
                     && !self.is_coordinator_contributor(&participant)
                 {
                     tracing::info!(

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2829,12 +2829,7 @@ impl CoordinatorState {
             .filter_map(|(participant, participant_info)| {
                 // Ensure we get the proper elapsed time since the last task was assigned.
                 // If no tasks have been assigned yet, we measure from the starting time.
-                let last_seen = if participant_info.last_released.is_none() {
-                    participant_info.first_seen
-                } else {
-                    participant_info.last_released.unwrap()
-                };
-
+                let last_seen = participant_info.last_released.unwrap_or(participant_info.first_seen);
                 let elapsed = now - last_seen;
 
                 if elapsed > participant_acceptance_timeout
@@ -2843,9 +2838,9 @@ impl CoordinatorState {
                 {
                     tracing::info!(
                         "Dropping participant {} because it has exceeded the maximum ({} minutes) allowed time \
-                    since it has last accepted a task from the coordinator (last accetped {} minutes ago).",
+                    since it has last accepted a task from the coordinator (last accepted {} minutes ago).",
                         participant,
-                        participant_acceptance_timeout,
+                        participant_acceptance_timeout.num_minutes(),
                         elapsed.num_minutes()
                     );
 

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -240,6 +240,11 @@ pub struct Environment {
     /// coordinator.
     #[serde_as(as = "DurationSecondsWithFrac<String>")]
     participant_lock_timeout: chrono::Duration,
+    /// Returns the maximum duration a participant can go without
+    /// accepting a task before it will be dropped from the ceremony by
+    /// the coordinator.
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    participant_acceptance_timeout: chrono::Duration,
     /// The number of drops tolerated by a participant before banning them from future rounds.
     participant_ban_threshold: u16,
     /// The setting to allow current contributors to join the queue for the next round.
@@ -373,6 +378,15 @@ impl Environment {
     ///
     pub const fn participant_lock_timeout(&self) -> chrono::Duration {
         self.participant_lock_timeout
+    }
+
+    ///
+    /// Returns the maximum duration a contributor can go without
+    /// accepting a task before it will be dropped from
+    /// the ceremony by the coordinator.
+    ///
+    pub const fn participant_acceptance_timeout(&self) -> chrono::Duration {
+        self.participant_acceptance_timeout
     }
 
     ///
@@ -537,6 +551,12 @@ impl Testing {
         deployment.environment.participant_lock_timeout = participant_lock_timeout;
         deployment
     }
+
+    pub fn participant_acceptance_timeout(&self, participant_acceptance_timeout: chrono::Duration) -> Self {
+        let mut deployment = self.clone();
+        deployment.environment.participant_acceptance_timeout = participant_acceptance_timeout;
+        deployment
+    }
 }
 
 impl From<Parameters> for Testing {
@@ -573,6 +593,7 @@ impl std::default::Default for Testing {
                 contributor_seen_timeout: chrono::Duration::minutes(5),
                 verifier_seen_timeout: chrono::Duration::minutes(15),
                 participant_lock_timeout: chrono::Duration::minutes(20),
+                participant_acceptance_timeout: chrono::Duration::minutes(15),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -675,6 +696,7 @@ impl std::default::Default for Development {
                 contributor_seen_timeout: chrono::Duration::minutes(5),
                 verifier_seen_timeout: chrono::Duration::minutes(15),
                 participant_lock_timeout: chrono::Duration::minutes(20),
+                participant_acceptance_timeout: chrono::Duration::minutes(15),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -771,6 +793,7 @@ impl std::default::Default for Production {
                 contributor_seen_timeout: chrono::Duration::minutes(5),
                 verifier_seen_timeout: chrono::Duration::minutes(15),
                 participant_lock_timeout: chrono::Duration::minutes(20),
+                participant_acceptance_timeout: chrono::Duration::minutes(15),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: false,
                 allow_current_verifiers_in_queue: true,


### PR DESCRIPTION
NOTE: not sure if the timeout chosen here is fine. It may make more sense to at least make it longer than the `last_seen` timeout, but I'm also not sure if we have any upper bounds on these kinds of timeouts.

Fixes #252 