### PR TITLE
Reduce power parameter for Inner SNARK

### DIFF
--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -124,7 +124,7 @@ impl Parameters {
             ContributionMode::Chunked,
             ProvingSystem::Groth16,
             CurveKind::Bls12_377,
-            Power::from(20_usize),
+            Power::from(19_usize),
             BatchSize::from(4096_usize),
             ChunkSize::from(32768_usize),
         )


### PR DESCRIPTION
Reduce the Inner SNARK power parameter to 2^19 from 2^20 based on optimizations made in snarkVM