### PR TITLE
Fix #304 manual restart fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-humanize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "ci_info"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2512,7 @@ dependencies = [
  "algebra",
  "anyhow",
  "chrono",
+ "chrono-humanize",
  "futures 0.3.8",
  "hex",
  "itertools",

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -20,6 +20,7 @@ zexe_algebra = { git = "https://github.com/scipr-lab/zexe", rev = "b24eda5", pac
 
 anyhow = { version = "1.0.37" }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-humanize = { version = "0.2" }
 itertools = { version = "0.9.0" }
 futures = { version = "0.3" }
 hex = { version = "0.4.2" }

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -904,7 +904,12 @@ where
     ///
     /// On failure, this function returns a `CoordinatorError`.
     ///
-    #[tracing::instrument(skip(self, participant), err)]
+    #[tracing::instrument(
+        level = "error",
+        skip(self),
+        fields(participant = %participant),
+        err
+    )]
     pub fn try_lock(&mut self, participant: &Participant) -> Result<(u64, LockedLocators), CoordinatorError> {
         // Check that the participant is in the current round, and has not been dropped or finished.
         if !self.state.is_current_contributor(participant) && !self.state.is_current_verifier(participant) {
@@ -985,7 +990,8 @@ where
     #[tracing::instrument(
         level = "error",
         skip(self, participant, chunk_id),
-        fields(chunk = chunk_id)
+        fields(participant = %participant, chunk = chunk_id),
+        err
     )]
     pub fn try_contribute(
         &mut self,
@@ -1110,7 +1116,12 @@ where
     ///
     /// On failure, it returns a `CoordinatorError`.
     ///
-    #[inline]
+    #[tracing::instrument(
+        level = "error",
+        skip(self, chunk_id),
+        fields(participant = %participant, chunk = chunk_id),
+        err
+    )]
     pub fn try_verify(&mut self, participant: &Participant, chunk_id: u64) -> Result<(), CoordinatorError> {
         // Check that the participant is a verifier.
         if !participant.is_verifier() {
@@ -1447,7 +1458,6 @@ where
     ///
     /// On failure, this function returns a `CoordinatorError`.
     ///
-    #[inline]
     pub(crate) fn try_lock_chunk(
         &mut self,
         chunk_id: u64,


### PR DESCRIPTION
Fix for #304 . Changes based on top of #311 

+ Remove contributions/verification files that were created when locks were
  taken and the locators initialized.
+ Some more tracing instrumentation.
+ Remove some unnecessary inlines.
+ Better logging for timeout drops.