### PR TITLE
Use stable toolchain in CI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
-#          - nightly
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,4 +39,3 @@ jobs:
 
       - name: Run phase1 full marlin
         run: cd phase1-cli && ./scripts/phase1_full.sh marlin
-

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -39,8 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
-#          - nightly
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -65,7 +64,7 @@ jobs:
         with:
           command: check
           args: --examples --all-features --all
-        if: matrix.rust == '1.53.0'
+        if: matrix.rust == 'stable'
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/setup1-cli-tools.yml
+++ b/.github/workflows/setup1-cli-tools.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/setup1-contributor.yml
+++ b/.github/workflows/setup1-contributor.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
-    #          - nightly
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,8 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
-    #          - nightly
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.53.0
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install WASM
         run: |
-          rustup target add wasm32-unknown-unknown --toolchain 1.53.0
+          rustup target add wasm32-unknown-unknown --toolchain stable
           cargo install wasm-bindgen-cli
           cargo update -p wasm-bindgen
 


### PR DESCRIPTION
Used "stable" instead of pinned version. This helps to stay up to date with toolchain version, for example 1.54 has been released recently