### PR TITLE
Replaced chrono Duration with std Duration in setup1-contributor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,6 @@ dependencies = [
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",
  "byteorder",
- "chrono",
  "clap",
  "futures",
  "futures-util",

--- a/setup1-contributor/Cargo.toml
+++ b/setup1-contributor/Cargo.toml
@@ -25,7 +25,6 @@ azure_sdk_storage_blob = { version = "0.45.3", optional = true }
 anyhow = { version = "1.0.33" }
 byteorder = { version = "1.3.4", optional = true }
 clap = { version = "2.33.3" }
-chrono = { version = "0.4", features = [ "serde" ] }
 futures = { version = "0.3" }
 futures-util = { version = "0.3.15", default-features = false, features = ["async-await", "sink", "std"] }
 hex = { version = "0.4" }


### PR DESCRIPTION
The chrono Duration was used in a following way:
```rust
Duration::seconds(DELAY_POLL_CEREMONY_SECS).to_std()?
```
and if you want to move this to a function which doesn't return Result, it'll become
```rust
.to_std().unwrap()
```
On the other side, Duration from std has `const fn` constructors which report errors in compile time instead of runtime