### PR TITLE
Updated contributor progress bar

### DIFF
--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -151,12 +151,7 @@ impl Contribute {
     }
 
     async fn run_and_catch_errors<E: PairingEngine>(&self) -> Result<()> {
-        let progress_bar = ProgressBar::new(0);
-        let progress_style =
-            ProgressStyle::default_bar().template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}");
-        progress_bar.enable_steady_tick(1000);
-        progress_bar.set_style(progress_style);
-        progress_bar.set_message("Getting initial data from the server...");
+        println!("Getting initial data from the server...");
 
         let join_result = self.join_queue(&mut rand::thread_rng()).await;
         match join_result {
@@ -239,7 +234,7 @@ impl Contribute {
 
         // This will only return once the contributor has completed all
         // of the work.
-        update_progress_bar(updater, progress_bar.clone()).await;
+        update_progress_bar(updater).await;
 
         futures::future::try_join_all(futures).await?;
 
@@ -914,15 +909,21 @@ impl Contribute {
     }
 }
 
-async fn update_progress_bar(updater: StatusUpdater, progress_bar: ProgressBar) {
+async fn update_progress_bar(updater: StatusUpdater) {
     // This function will only be called if the contributor is already
     // in the queue. So, we can just print it here and leave it.
     println!(
         "You are in the queue for an upcoming round of the ceremony. \
         Please wait for the prior round to finish, and please stay \
-        connected for the duration of your contribution.\n",
+        connected for the duration of your contribution.",
     );
 
+    let progress_bar = ProgressBar::new(0);
+    let progress_style =
+        ProgressStyle::default_bar().template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}");
+    progress_bar.enable_steady_tick(1000);
+    progress_bar.set_style(progress_style);
+    progress_bar.set_message("Getting initial data from the server...");
     loop {
         match updater.status_updater(progress_bar.clone()).await {
             Ok(_) => {

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -944,13 +944,20 @@ impl StatusUpdater {
         let status = get_contributor_status(&self.server_url, &self.private_key).await?;
         match status {
             ContributorStatus::Queue => {
-                progress_bar.set_message(&"In queue for one of the future rounds");
+                progress_bar.set_message(
+                    &"You are in the queue for an upcoming round of the ceremony. \
+                    Please wait for the prior round to finish, and please stay \
+                    connected for the duration of your contribution.",
+                );
             }
             ContributorStatus::Round => {
                 self.update_position_in_round(&progress_bar).await?;
             }
             ContributorStatus::Other => {
-                progress_bar.set_message(&"Neither in queue nor in the current round");
+                progress_bar.set_message(
+                    &"Not in the queue for Aleo Setup ceremony. Please double check the address \
+                    you are connecting, then disconnect and try again",
+                );
             }
         }
 

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -958,7 +958,7 @@ impl StatusUpdater {
                 self.update_position_in_round(&progress_bar).await?;
             }
             ContributorStatus::Finished => {
-                let completed_message = "Successfully contributed, thank you for participation! Waiting to see if you're still needed... Don't turn this off!";
+                let completed_message = "Finished!";
 
                 progress_bar.finish_with_message(completed_message);
                 info!(completed_message);
@@ -994,7 +994,7 @@ impl StatusUpdater {
             ));
             progress_bar.set_position((number_of_chunks - non_contributed_chunks.len()) as u64);
         } else if non_contributed_chunks.len() == 0 {
-            let completed_message = "Successfully contributed, thank you for participation! Waiting to see if you're still needed... Don't turn this off!";
+            let completed_message = "Finished!";
 
             progress_bar.finish_with_message(completed_message);
             info!(completed_message);

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -945,7 +945,7 @@ impl StatusUpdater {
         match status {
             ContributorStatus::Queue => {
                 progress_bar.set_message(
-                    &"You are in the queue for an upcoming round of the ceremony. \
+                    "You are in the queue for an upcoming round of the ceremony. \
                     Please wait for the prior round to finish, and please stay \
                     connected for the duration of your contribution.",
                 );
@@ -954,9 +954,9 @@ impl StatusUpdater {
                 self.update_position_in_round(&progress_bar).await?;
             }
             ContributorStatus::Other => {
-                progress_bar.set_message(
-                    &"Not in the queue for Aleo Setup ceremony. Please double check the address \
-                    you are connecting, then disconnect and try again",
+                progress_bar.finish_with_message(
+                    "Not in the queue for Aleo Setup ceremony. Please double check the address \
+                    you are connecting to, then disconnect and try again",
                 );
             }
         }

--- a/setup1-contributor/src/setup_keys/confirmation_key.rs
+++ b/setup1-contributor/src/setup_keys/confirmation_key.rs
@@ -74,12 +74,12 @@ impl ConfirmationKey {
 
 pub fn print_key_and_remove_the_file() -> Result<()> {
     let key_file = ConfirmationKey::read_from_disk()?;
-    println!("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
+    println!("|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
     println!("Your address is {}", key_file.address);
     println!("And confirmation key is {}", key_file.private_key);
     println!("Store this information in order to prove your participation in the setup");
     println!("Do not share the confirmation key with others!");
-    println!("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
+    println!("|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
     std::fs::remove_file(CONFIRMATION_KEY_FILE)?;
     Ok(())
 }

--- a/setup1-shared/src/structures.rs
+++ b/setup1-shared/src/structures.rs
@@ -53,3 +53,11 @@ pub struct TwitterInfo {
     pub request_token: egg_mode::KeyPair,
     pub pin: String,
 }
+
+/// The status of the contributor related to the current round
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ContributorStatus {
+    Queue,
+    Round,
+    Other,
+}

--- a/setup1-shared/src/structures.rs
+++ b/setup1-shared/src/structures.rs
@@ -59,5 +59,6 @@ pub struct TwitterInfo {
 pub enum ContributorStatus {
     Queue,
     Round,
+    Finished,
     Other,
 }


### PR DESCRIPTION
Updated progress bar messages. Show the number of tasks only if the contributor is in the current round. If the contributor in the queue, show that it's in the queue