### PR TITLE
Fix verifier stall by adding missing logic for deleting response files

### DIFF
--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -944,9 +944,6 @@ impl Round {
                 Participant::Verifier(_) => {
                     // Get the response locator
                     let current_contribution_id = chunk.current_contribution_id();
-                    if current_contribution_id == 0 {
-                        return Err(CoordinatorError::ChunkCannotLockZeroContributions { chunk_id: *chunk_id });
-                    }
 
                     let is_final_contribution = chunk.only_contributions_complete(expected_number_of_contributions);
 


### PR DESCRIPTION
Fixes #305

The PR also includes a test which isolates the specific failure case. It can be pasted into the master branch and ran, and there you can see it will fail, making it easy to verify that this PR solved the issue.