### PR TITLE
#368 use fs-err for improved error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ebd3504ad6116843b8375ad70df74e7bfe83cac77a1f3fe73200c844d43bfe0"
+
+[[package]]
 name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1870,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "chrono-humanize",
+ "fs-err",
  "futures",
  "hex",
  "itertools",
@@ -2745,6 +2752,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "egg-mode",
+ "fs-err",
  "futures",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
 name = "phase1-cli"
 version = "0.3.0"
 dependencies = [
+ "fs-err",
  "gumdrop",
  "hex",
  "memmap",
@@ -2804,6 +2805,10 @@ name = "setup1-verifier"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "ctrlc",
+ "fs-err",
+ "futures-util",
  "hex",
  "http",
  "phase1",
@@ -2834,6 +2839,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
+ "fs-err",
  "gumdrop",
  "hex",
  "hex-literal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1601,19 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
+
+[[package]]
+name = "nix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -13,6 +13,7 @@ phase1 = { path = "../phase1" }
 setup-utils = { path = "../setup-utils" }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
+fs-err = "2.6"
 gumdrop = { version = "0.8.0" }
 hex = { version = "0.4.2" }
 memmap = { version = "0.7.0" }

--- a/phase1-cli/src/transform_ratios.rs
+++ b/phase1-cli/src/transform_ratios.rs
@@ -3,8 +3,8 @@ use setup_utils::{calculate_hash, print_hash, CheckForCorrectness, UseCompressio
 
 use snarkvm_curves::PairingEngine as Engine;
 
+use fs_err::OpenOptions;
 use memmap::*;
-use std::fs::OpenOptions;
 
 pub fn transform_ratios<T: Engine + Sync>(response_filename: &str, parameters: &Phase1Parameters<T>) {
     println!(

--- a/phase1-cli/src/transform_ratios.rs
+++ b/phase1-cli/src/transform_ratios.rs
@@ -42,7 +42,7 @@ pub fn transform_ratios<T: Engine + Sync>(response_filename: &str, parameters: &
 
     let response_readable_map = unsafe {
         MmapOptions::new()
-            .map(&response_reader)
+            .map(&response_reader.file())
             .expect("unable to create a memory map for input")
     };
 

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -21,6 +21,7 @@ snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"
 anyhow = { version = "1.0.37" }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = { version = "0.2" }
+fs-err = { version = "2.6.0" }
 itertools = "0.10"
 futures = { version = "0.3" }
 hex = { version = "0.4.2" }

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -2,10 +2,17 @@ use crate::{
     environment::Environment,
     objects::{ContributionFileSignature, Round},
     storage::{
-        ContributionLocator, ContributionSignatureLocator, Locator, Object, ObjectReader, ObjectWriter, StorageLocator,
+        ContributionLocator,
+        ContributionSignatureLocator,
+        Locator,
+        Object,
+        ObjectReader,
+        ObjectWriter,
+        StorageLocator,
         StorageObject,
     },
-    CoordinatorError, CoordinatorState,
+    CoordinatorError,
+    CoordinatorState,
 };
 
 use anyhow::Result;

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -11,7 +11,7 @@ use memmap::MmapMut;
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{RwLockReadGuard, RwLockWriteGuard},
 };
 
@@ -202,6 +202,12 @@ pub struct LocatorPath(String);
 impl AsRef<Path> for LocatorPath {
     fn as_ref(&self) -> &Path {
         self.as_path()
+    }
+}
+
+impl Into<PathBuf> for LocatorPath {
+    fn into(self) -> PathBuf {
+        self.as_path().into()
     }
 }
 

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -15,6 +15,7 @@ use serial_test::serial;
 use std::{path::Path, sync::Arc};
 use tracing::*;
 
+use fs_err as fs;
 use once_cell::sync::OnceCell;
 
 static INSTANCE: OnceCell<()> = OnceCell::new();
@@ -98,7 +99,7 @@ fn clear_test_storage(environment: &Environment) {
     let path = environment.local_base_directory();
     if Path::new(path).exists() {
         warn!("Coordinator is clearing {:?}", &path);
-        match std::fs::remove_dir_all(&path) {
+        match fs::remove_dir_all(&path) {
             Ok(_) => (),
             Err(error) => error!(
                 "The testing framework tried to clear the test transcript and failed. {}",

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -14,6 +14,7 @@ use crate::{
 use chrono::Utc;
 use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
 
+use fs_err as fs;
 use rand::RngCore;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
@@ -1342,7 +1343,7 @@ fn check_round_matches_storage_files(storage: &Disk, round: &Round) {
         let path = initial_challenge_location.as_path();
         let chunk_dir = path.parent().unwrap();
 
-        let n_files = std::fs::read_dir(&chunk_dir).unwrap().count();
+        let n_files = fs::read_dir(&chunk_dir).unwrap().count();
 
         let contributions_complete = chunk.only_contributions_complete(round.expected_number_of_contributions());
 

--- a/setup1-contributor/Cargo.toml
+++ b/setup1-contributor/Cargo.toml
@@ -24,6 +24,7 @@ blake2 = "0.9"
 clap = { version = "2.33.3" }
 dialoguer = "0.8"
 egg-mode = "0.16"
+fs-err = "2.6"
 futures = { version = "0.3" }
 futures-util = { version = "0.3.15", default-features = false, features = ["async-await", "sink", "std"] }
 hex = { version = "0.4" }

--- a/setup1-contributor/src/commands/contribute.rs
+++ b/setup1-contributor/src/commands/contribute.rs
@@ -31,6 +31,7 @@ use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, Address, PrivateKey,
 use age::DecryptError;
 use anyhow::{Context, Result};
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
+use fs_err::File;
 use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
 use panic_control::{spawn_quiet, ThreadResultExt};
@@ -41,10 +42,9 @@ use setup_utils::derive_rng_from_seed;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     convert::TryFrom,
-    fs::File,
     io::{Read, Write},
     ops::Deref,
-    path::Path,
+    path::PathBuf,
     str::FromStr,
     sync::{Arc, RwLock},
     time::Duration,
@@ -1152,12 +1152,12 @@ fn decrypt(passphrase: &SecretString, encrypted: &str) -> Result<Vec<u8>> {
 
 /// Decrypts and reads the private key from the specified `keys_path`,
 /// decrypting using the specified `passphrase`
-fn read_keys<P: AsRef<Path>>(
+fn read_keys<P: Into<PathBuf>>(
     keys_path: P,
     passphrase: &SecretString,
 ) -> Result<(SecretVec<u8>, PrivateKey<Testnet2Parameters>)> {
     let mut contents = String::new();
-    std::fs::File::open(keys_path)?.read_to_string(&mut contents)?;
+    File::open(keys_path)?.read_to_string(&mut contents)?;
     let keys: AleoSetupKeys = serde_json::from_str(&contents)?;
 
     let seed = SecretVec::new(decrypt(passphrase, &keys.encrypted_seed)?);

--- a/setup1-contributor/src/commands/generate.rs
+++ b/setup1-contributor/src/commands/generate.rs
@@ -1,9 +1,10 @@
+use fs_err::File;
 use std::io::Write;
 
 use crate::cli::commands::generate::GenerateOptions;
 
 pub fn generate_keys(opts: GenerateOptions) {
-    let mut file = std::fs::File::create(&opts.keys_path).expect("Should have created keys file");
+    let mut file = File::create(&opts.keys_path).expect("Should have created keys file");
     let passphrase = crate::setup_keys::read_or_generate_passphrase(opts.passphrase);
 
     println!("\nDO NOT FORGET YOUR PASSPHRASE!\n\nYou will need your passphrase to access your keys.\n\n");

--- a/setup1-contributor/src/setup_keys/confirmation_key.rs
+++ b/setup1-contributor/src/setup_keys/confirmation_key.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use blake2::{Blake2s, Digest};
+use fs_err as fs;
 use serde::{Deserialize, Serialize};
 
 const CONFIRMATION_KEY_FILE: &str = ".confirmation_key";
@@ -51,14 +52,14 @@ impl ConfirmationKey {
     }
 
     fn read_from_disk() -> Result<Self> {
-        let bytes = std::fs::read(CONFIRMATION_KEY_FILE)?;
+        let bytes = fs::read(CONFIRMATION_KEY_FILE)?;
         let key_file = serde_json::from_slice(&bytes)?;
         Ok(key_file)
     }
 
     fn write_to_disk(&self) -> Result<()> {
         let bytes = serde_json::to_vec(self)?;
-        std::fs::write(CONFIRMATION_KEY_FILE, bytes)?;
+        fs::write(CONFIRMATION_KEY_FILE, bytes)?;
         Ok(())
     }
 
@@ -80,6 +81,6 @@ pub fn print_key_and_remove_the_file() -> Result<()> {
     println!("Store this information in order to prove your participation in the setup");
     println!("Do not share the confirmation key with others!");
     println!("|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
-    std::fs::remove_file(CONFIRMATION_KEY_FILE)?;
+    fs::remove_file(CONFIRMATION_KEY_FILE)?;
     Ok(())
 }

--- a/setup1-contributor/src/utils.rs
+++ b/setup1-contributor/src/utils.rs
@@ -10,9 +10,9 @@ use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, Address, PrivateKey,
 use snarkvm_utilities::ToBytes;
 
 use anyhow::Result;
-use rand::{CryptoRng, Rng};
 #[cfg(test)]
-use std::fs::{create_dir_all, write};
+use fs_err::{create_dir_all, write};
+use rand::{CryptoRng, Rng};
 use std::{
     convert::TryFrom,
     fs::{remove_file, File},

--- a/setup1-verifier/Cargo.toml
+++ b/setup1-verifier/Cargo.toml
@@ -21,6 +21,10 @@ snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"
 snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM", rev = "fc997c" }
 
 anyhow = { version = "1.0.32" }
+chrono = { version = "0.4", features = ["serde"] }
+ctrlc = { version = "3.1.7" }
+fs-err = { version = "2.6" }
+futures-util = { version = "0.3.5" }
 hex = { version = "0.4.2" }
 http = "0.2"
 rand = { version = "0.8" }

--- a/setup1-verifier/src/main.rs
+++ b/setup1-verifier/src/main.rs
@@ -9,9 +9,6 @@ use url::Url;
 
 mod coordinator_requests;
 mod errors;
-use fs_err as fs;
-mod objects;
-mod tasks;
 mod utils;
 mod verifier;
 
@@ -78,14 +75,7 @@ async fn main() {
         SetupKind::Universal => universal(),
     };
 
-<<<<<<< HEAD
     let raw_view_key = std::fs::read_to_string(options.view_key).expect("View key not found");
-=======
-    let storage_prefix = format!("{:?}", public_settings.setup).to_lowercase();
-    let tasks_storage_path = format!("{}_verifier.tasks", storage_prefix);
-
-    let raw_view_key = fs::read_to_string(options.view_key).expect("View key not found");
->>>>>>> c91f4ba (#368 swap remaining usages of std::fs to fs-err)
     let view_key = ViewKey::<Testnet2Parameters>::from_str(&raw_view_key).expect("Invalid view key");
     let address = Address::from_view_key(&view_key).expect("Address not derived correctly");
 

--- a/setup1-verifier/src/main.rs
+++ b/setup1-verifier/src/main.rs
@@ -9,6 +9,9 @@ use url::Url;
 
 mod coordinator_requests;
 mod errors;
+use fs_err as fs;
+mod objects;
+mod tasks;
 mod utils;
 mod verifier;
 
@@ -75,7 +78,14 @@ async fn main() {
         SetupKind::Universal => universal(),
     };
 
+<<<<<<< HEAD
     let raw_view_key = std::fs::read_to_string(options.view_key).expect("View key not found");
+=======
+    let storage_prefix = format!("{:?}", public_settings.setup).to_lowercase();
+    let tasks_storage_path = format!("{}_verifier.tasks", storage_prefix);
+
+    let raw_view_key = fs::read_to_string(options.view_key).expect("View key not found");
+>>>>>>> c91f4ba (#368 swap remaining usages of std::fs to fs-err)
     let view_key = ViewKey::<Testnet2Parameters>::from_str(&raw_view_key).expect("Invalid view key");
     let address = Address::from_view_key(&view_key).expect("Address not derived correctly");
 

--- a/setup2/Cargo.toml
+++ b/setup2/Cargo.toml
@@ -22,6 +22,7 @@ snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc99
 
 anyhow = { version = "1.0.37" }
 cfg-if = "1.0"
+fs-err = { version = "2.6" }
 gumdrop = { version = "0.8.0", optional = true }
 hex = { version = "0.4.2" }
 hex-literal = { version = "0.3.1", optional = true }

--- a/setup2/src/cli/contribute.rs
+++ b/setup2/src/cli/contribute.rs
@@ -3,10 +3,10 @@ use setup_utils::Result;
 
 use snarkvm_curves::{bls12_377::Bls12_377, bw6_761::BW6_761};
 
+use fs_err::OpenOptions;
 use gumdrop::Options;
 use memmap::MmapOptions;
 use rand::{CryptoRng, Rng};
-use std::fs::OpenOptions;
 
 #[derive(Debug, Options, Clone)]
 pub struct ContributeOpts {
@@ -43,7 +43,7 @@ pub fn contribute<R: Rng + CryptoRng>(opts: &ContributeOpts, rng: &mut R) -> Res
     }
     let mut file = unsafe {
         MmapOptions::new()
-            .map_mut(&file)
+            .map_mut(file.file())
             .expect("unable to create a memory map for input")
     };
 

--- a/setup2/src/cli/new.rs
+++ b/setup2/src/cli/new.rs
@@ -9,11 +9,11 @@ use snarkvm_dpc::{
 use snarkvm_fields::Field;
 use snarkvm_r1cs::{ConstraintCounter, ConstraintSynthesizer};
 
+use fs_err::OpenOptions;
 use gumdrop::Options;
 use memmap::MmapOptions;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
-use std::fs::OpenOptions;
 
 type AleoInner = <Testnet2Parameters as Parameters>::InnerCurve;
 type AleoOuter = <Testnet2Parameters as Parameters>::OuterCurve;
@@ -128,7 +128,7 @@ pub fn generate_params<Aleo: PairingEngine, Zexe: PairingEngine, C: Clone + Cons
         .expect("could not read phase 1 transcript file");
     let mut phase1_transcript = unsafe {
         MmapOptions::new()
-            .map_mut(&phase1_transcript)
+            .map_mut(phase1_transcript.file())
             .expect("unable to create a memory map for input")
     };
     let mut output = OpenOptions::new()

--- a/setup2/src/cli/verify.rs
+++ b/setup2/src/cli/verify.rs
@@ -3,9 +3,9 @@ use setup_utils::Result;
 
 use snarkvm_curves::{bls12_377::Bls12_377, bw6_761::BW6_761};
 
+use fs_err::OpenOptions;
 use gumdrop::Options;
 use memmap::MmapOptions;
-use std::fs::OpenOptions;
 
 // Options for the Contribute command
 #[derive(Debug, Options, Clone)]
@@ -29,7 +29,7 @@ pub fn verify(opts: &VerifyOpts) -> Result<()> {
         .expect("could not read the previous participant's MPC transcript file");
     let mut before = unsafe {
         MmapOptions::new()
-            .map_mut(&before)
+            .map_mut(before.file())
             .expect("unable to create a memory map for input")
     };
     let after = OpenOptions::new()
@@ -39,7 +39,7 @@ pub fn verify(opts: &VerifyOpts) -> Result<()> {
         .expect("could not read the previous participant's MPC transcript file");
     let mut after = unsafe {
         MmapOptions::new()
-            .map_mut(&after)
+            .map_mut(after.file())
             .expect("unable to create a memory map for input")
     };
     if opts.is_inner {


### PR DESCRIPTION
#368 refactor some key useages of `std::fs` to use `fs-err` instead for improved error messages. 

Please do not merge before #361 

TODO: fix an error compiling unit tests