### PR TITLE
Phase2 requirements

### DIFF
--- a/e2e_inner.sh
+++ b/e2e_inner.sh
@@ -3,18 +3,20 @@
 rm -f challenge* response* new_challenge* processed*
 
 POWER=19
-BATCH=10000
+BATCH=1000
 CURVE="bls12_377"
+SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
+echo $SEED > seed1
 
-phase1="cargo run --bin phase1 --release -- --curve-kind $CURVE --batch-size $BATCH --power $POWER"
-phase2="cargo run --release --bin prepare_phase2 -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
-snark="cargo run --release --bin setup2 --"
+phase1="cargo run --release --bin phase1 --features cli -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed seed1 --proving-system groth16"
+phase2="cargo run --release --bin prepare_phase2 --features=cli -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
+snark="cargo run --release --bin setup2 --features=cli --"
 
 ####### Phase 1
 
 $phase1 new --challenge-fname challenge
 yes | $phase1 contribute --challenge-fname challenge --response-fname response
-$phase1 verify-and-transform --challenge-fname challenge --response-fname response --new-challenge-fname new_challenge
+$phase1 verify-and-transform-pok-and-correctness --challenge-fname challenge --response-fname response --new-challenge-fname new_challenge
 rm challenge new_challenge # no longer needed
 
 ###### Prepare Phase 2
@@ -23,6 +25,7 @@ $phase2 --response-fname response --phase2-fname processed --phase2-size $POWER
 
 ###### Phase 2
 
+rm initial_ceremony
 $snark new --phase1 processed --output initial_ceremony --phase1-size $POWER --is-inner
 
 cp initial_ceremony contribution1

--- a/e2e_inner.sh
+++ b/e2e_inner.sh
@@ -3,14 +3,14 @@
 rm -f challenge* response* new_challenge* processed*
 
 POWER=19
-BATCH=1000
+BATCH=10000
 CURVE="bls12_377"
 SEED=`tr -dc 'A-F0-9' < /dev/urandom | head -c32`
 echo $SEED > seed1
 
 phase1="cargo run --release --bin phase1 --features cli -- --curve-kind $CURVE --batch-size $BATCH --contribution-mode full --power $POWER --seed seed1 --proving-system groth16"
-phase2="cargo run --release --bin prepare_phase2 --features=cli -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
-snark="cargo run --release --bin setup2 --features=cli --"
+phase2="cargo run --release --bin prepare_phase2 --features cli -- --curve-kind $CURVE --batch-size $BATCH --power $POWER --phase2-size $POWER"
+snark="cargo run --release --bin setup2 --features cli --"
 
 ####### Phase 1
 

--- a/e2e_inner.sh
+++ b/e2e_inner.sh
@@ -25,7 +25,6 @@ $phase2 --response-fname response --phase2-fname processed --phase2-size $POWER
 
 ###### Phase 2
 
-rm initial_ceremony
 $snark new --phase1 processed --output initial_ceremony --phase1-size $POWER --is-inner
 
 cp initial_ceremony contribution1

--- a/e2e_outer.sh
+++ b/e2e_outer.sh
@@ -25,7 +25,6 @@ $phase2 --response-fname response --phase2-fname processed --phase2-size $POWER
 
 ###### Phase 2
 
-rm initial_ceremony
 $snark new --phase1 processed --output initial_ceremony --phase1-size $POWER
 
 cp initial_ceremony contribution1

--- a/phase2/Cargo.toml
+++ b/phase2/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["phase2/testing"]
 [dependencies]
 setup-utils = { path = "../setup-utils" }
 
-snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false }
+snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false, features = ["snark"] }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
@@ -28,6 +28,7 @@ snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc99
 byteorder = { version = "1.3.4" }
 cfg-if = "1.0"
 crossbeam = { version = "0.8" }
+hex = { version = "0.4.3" }
 itertools = { version = "0.10", optional = true }
 num_cpus = { version = "1" }
 rand = { version = "0.8" }

--- a/phase2/src/keypair.rs
+++ b/phase2/src/keypair.rs
@@ -2,12 +2,13 @@
 //!
 //! A Groth16 keypair. Generate one with the Keypair::new method.
 //! Dispose of the private key ASAP once it's been used.
-use setup_utils::{hash_to_g2, CheckForCorrectness, Deserializer, HashWriter, Result, Serializer, UseCompression};
+use setup_utils::{CheckForCorrectness, Deserializer, HashWriter, Result, Serializer, UseCompression};
 use snarkvm_curves::{PairingEngine, ProjectiveCurve};
 use snarkvm_utilities::{CanonicalSerialize, ConstantSerializedSize, UniformRand};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use rand::Rng;
+use snarkvm_algorithms::hash_to_curve::hash_to_curve;
 use std::{
     fmt,
     io::{self, Read, Write},
@@ -131,7 +132,7 @@ impl<E: PairingEngine> Keypair<E> {
         // Get the transcript
         let transcript = hash_cs_pubkeys(cs_hash, contributions, s, s_delta);
         // Compute delta s-pair in G2 by hashing the transcript and multiplying it by delta
-        let r = hash_to_g2::<E>(&transcript[..]).into_affine();
+        let r = hash_to_curve::<E::G2Affine>(&hex::encode(transcript[..].as_ref())).0;
         let r_delta = r.mul(delta);
 
         Self {

--- a/setup-utils/Cargo.toml
+++ b/setup-utils/Cargo.toml
@@ -14,7 +14,7 @@ name = "math"
 harness = false
 
 [dependencies]
-snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false, features = ["fft"] }
+snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false, features = ["fft", "hash_to_curve", "crypto_hash", "blake2"] }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
@@ -24,6 +24,7 @@ blake2 = "0.9"
 blake2s_simd = { version = "0.5.11" }
 cfg-if = "1.0"
 crossbeam = { version = "0.8.0" }
+hex = { version = "0.4.3" }
 num_cpus = { version = "1.12.0" }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }


### PR DESCRIPTION
This PR fixes:
* RNG usage on phase2 
* replace old implementation by new hash_to_curve function
* update e2e scripts (tested locally): 
  ** e2e_inner.sh finished after 3 or 4 hours in total
  ** e2e_outer.sh got killed after several hours (10 hours just to prepare for phase2) while checking the result of preparation, see last prints: 
```  
before AHP: constraints: 415012
before PC checks: constraints: 451343
before PC combining commitments: constraints: 451343
before PC batch check: constraints: 496530
after PC batch check: constraints: 542162
before AHP: constraints: 565020
before PC checks: constraints: 601351
before PC combining commitments: constraints: 601351
before PC batch check: constraints: 646538
after PC batch check: constraints: 692170
./e2e_outer.sh: line 29: 597790 Killed                  $snark new --phase1 processed --output initial_ceremony --phase1-size $POWER
```