### PR TITLE
Remove unnecessary errors related to getting round height in tests

### DIFF
--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -2199,17 +2199,16 @@ impl Coordinator {
 
     #[inline]
     fn load_current_round_height(storage: &Disk) -> Result<u64, CoordinatorError> {
-        match storage.exists(&Locator::RoundHeight) {
-            true => {
-                // Fetch the current round height from storage.
-                match storage.get(&Locator::RoundHeight)? {
-                    // Case 1 - This is a typical round of the ceremony.
-                    Object::RoundHeight(current_round_height) => Ok(current_round_height),
-                    // Case 2 - Storage failed to fetch the round height.
-                    _ => Err(CoordinatorError::StorageFailed),
-                }
+        if storage.exists(&Locator::RoundHeight) {
+            // Fetch the current round height from storage.
+            match storage.get(&Locator::RoundHeight)? {
+                // Case 1 - This is a typical round of the ceremony.
+                Object::RoundHeight(current_round_height) => Ok(current_round_height),
+                // Case 2 - Storage failed to fetch the round height.
+                _ => Err(CoordinatorError::StorageFailed),
             }
-            false => Err(CoordinatorError::RoundHeightNotSet),
+        } else {
+            Err(CoordinatorError::RoundHeightNotSet)
         }
     }
 

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -2199,12 +2199,17 @@ impl Coordinator {
 
     #[inline]
     fn load_current_round_height(storage: &Disk) -> Result<u64, CoordinatorError> {
-        // Fetch the current round height from storage.
-        match storage.get(&Locator::RoundHeight)? {
-            // Case 1 - This is a typical round of the ceremony.
-            Object::RoundHeight(current_round_height) => Ok(current_round_height),
-            // Case 2 - Storage failed to fetch the round height.
-            _ => Err(CoordinatorError::StorageFailed),
+        match storage.exists(&Locator::RoundHeight) {
+            true => {
+                // Fetch the current round height from storage.
+                match storage.get(&Locator::RoundHeight)? {
+                    // Case 1 - This is a typical round of the ceremony.
+                    Object::RoundHeight(current_round_height) => Ok(current_round_height),
+                    // Case 2 - Storage failed to fetch the round height.
+                    _ => Err(CoordinatorError::StorageFailed),
+                }
+            }
+            false => Err(CoordinatorError::RoundHeightNotSet),
         }
     }
 

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -152,7 +152,7 @@ impl Disk {
 
         // Check that the given locator exists in storage.
         if !self.exists(locator) {
-            error!("Locator missing in call to get() in storage.");
+            error!("Locator missing in call to get() in storage - {:?}", locator);
             return Err(CoordinatorError::StorageLocatorMissing);
         }
 


### PR DESCRIPTION
The error was caused by immediately using the `get()` call when trying to see if the round height file had been created yet. This will log an error if the file is missing, and thus preceding it with an `exists()` call will silence this error.

Fixes #336