### PR TITLE
Delete existing round file if trying to aggregate

### DIFF
--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -1879,11 +1879,11 @@ impl Coordinator {
             round_height: current_round_height,
         };
         if self.storage.exists(&round_file) {
-            error!(
-                "Round file locator already exists ({})",
+            warn!(
+                "Round file locator already exists ({}), removing...",
                 self.storage.to_path(&round_file)?
             );
-            return Err(CoordinatorError::RoundLocatorAlreadyExists);
+            self.storage.remove(&round_file)?;
         }
 
         // Fetch the current round from storage.


### PR DESCRIPTION
This will ensure the coordinator wont crash
if it has been accidentally turned off during aggregation.