### PR TITLE
Include unit test to check Marlin SRS from ceremony

### DIFF
--- a/phase1-cli/scripts/phase1_chunked.sh
+++ b/phase1-cli/scripts/phase1_chunked.sh
@@ -11,7 +11,7 @@ if [ "$PROVING_SYSTEM" == "groth16" ]; then
 else
   MAX_CHUNK_INDEX=1 # we have 2 chunks, since we have a total of 2^11-1 powers
 fi
-CURVE="bw6"
+CURVE="bls12_377"
 SEED1=`tr -dc 'A-F0-9' < /dev/random | head -c32`
 echo $SEED1 > seed1
 SEED2=`tr -dc 'A-F0-9' < /dev/random | head -c32`

--- a/phase1/Cargo.toml
+++ b/phase1/Cargo.toml
@@ -38,6 +38,7 @@ snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = { version = "1.0.37" }
 blake2 = { version = "0.9", default-features = false }
+memmap = { version = "0.7.0" }
 num-traits = { version = "0.2.12" }
 rand_chacha = { version = "0.3" }
 rusty-hook = { version = "0.11.2" }


### PR DESCRIPTION
We can download from latest round of ceremony the file `round_[NUM].verified` and modify the unit test included in this PR to check if such SRS can be used to generate and verify proofs. 