### PR TITLE
Fix included readme doc

### DIFF
--- a/phase1-cli/README.md
+++ b/phase1-cli/README.md
@@ -13,7 +13,7 @@ Coordinators run:
 
 Users should only care about the `contribute` option.
 
-```ignore
+```text
 $ ./phase1 --help
 Usage: ./phase1 [OPTIONS]
 
@@ -40,7 +40,7 @@ Available commands:
 This binary will only be run by the coordinator after Phase 1 has been executed.
 Note that the parameters produced are **only for the Groth16 SNARK**.
 
-```ignore
+```text
 ./prepare_phase2 --help
 Usage: ./prepare_phase2 [OPTIONS]
 
@@ -64,8 +64,8 @@ Optional arguments:
 
 This work is licensed under either of the following licenses, at your discretion.
 
-- Apache License Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+- Apache License Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
 as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -1,6 +1,5 @@
 // Documentation
-#![cfg_attr(nightly, feature(doc_cfg, external_doc))]
-#![cfg_attr(nightly, doc(include = "../README.md"))]
+#![doc = include_str!("../README.md")]
 
 mod combine;
 pub use combine::combine;


### PR DESCRIPTION
Removes the old nightly doc features in favour of the stabilised `include_str!`. 

Opened against `master`, please advise if this isn't the correct branch. 