### PR TITLE
Feat: keep track of participant IPs

### DIFF
--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -563,14 +563,6 @@ impl Coordinator {
     }
 
     ///
-    /// Returns `true` if a contributor has already entered the queue with this IP.
-    ///
-    #[inline]
-    pub fn is_duplicate_ip(&self, ip: &IpAddr) -> bool {
-        self.state.is_duplicate_ip(ip)
-    }
-
-    ///
     /// Returns `true` if the given participant is a contributor in the queue.
     ///
     #[inline]
@@ -864,15 +856,6 @@ impl Coordinator {
     /// and participating (or waiting to participate) in the ceremony.
     pub fn heartbeat(&mut self, participant: &Participant) -> Result<(), CoordinatorError> {
         self.state.heartbeat(participant, self.time.as_ref())
-    }
-
-    ///
-    /// Updates the coordinator's state by zeroing the reliability score for participants using
-    /// the same IP.
-    ///
-    #[inline]
-    pub fn zero_duplicate_ips(&mut self, ip: &IpAddr) {
-        self.state.zero_duplicate_ips(ip)
     }
 
     ///

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -33,6 +33,7 @@ use setup_utils::calculate_hash;
 use chrono::{DateTime, Utc};
 use std::{
     fmt,
+    net::IpAddr,
     sync::{Arc, RwLock},
 };
 use tracing::*;
@@ -562,6 +563,14 @@ impl Coordinator {
     }
 
     ///
+    /// Returns `true` if a contributor has already entered the queue with this IP.
+    ///
+    #[inline]
+    pub fn is_duplicate_ip(&self, ip: &IpAddr) -> bool {
+        self.state.is_duplicate_ip(ip)
+    }
+
+    ///
     /// Returns `true` if the given participant is a contributor in the queue.
     ///
     #[inline]
@@ -571,7 +580,7 @@ impl Coordinator {
 
     ///
     /// Returns the total number of contributors currently in the queue.
-    ///  
+    ///
     #[inline]
     pub fn number_of_queue_contributors(&self) -> usize {
         self.state.number_of_queue_contributors()
@@ -850,6 +859,15 @@ impl Coordinator {
     /// and participating (or waiting to participate) in the ceremony.
     pub fn heartbeat(&mut self, participant: &Participant) -> Result<(), CoordinatorError> {
         self.state.heartbeat(participant, self.time.as_ref())
+    }
+
+    ///
+    /// Updates the coordinator's state by zeroing the reliability score for participants using
+    /// the same IP.
+    ///
+    #[inline]
+    pub fn zero_duplicate_ips(&mut self, ip: &IpAddr) {
+        self.state.zero_duplicate_ips(ip)
     }
 
     ///

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -625,7 +625,7 @@ impl Coordinator {
     pub fn add_to_queue(
         &mut self,
         participant: Participant,
-        participant_ip: IpAddr,
+        participant_ip: Option<IpAddr>,
         reliability_score: u8,
     ) -> Result<(), CoordinatorError> {
         // Attempt to add the participant to the next round.
@@ -2705,9 +2705,12 @@ mod tests {
 
             // Add the contributor and verifier of the coordinator to execute round 1.
             for (contributor, contributor_ip) in contributors {
-                coordinator
-                    .state
-                    .add_to_queue(contributor.clone(), *contributor_ip, 10, coordinator.time.as_ref())?;
+                coordinator.state.add_to_queue(
+                    contributor.clone(),
+                    Some(*contributor_ip),
+                    10,
+                    coordinator.time.as_ref(),
+                )?;
             }
 
             // Update the queue.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -3396,6 +3396,37 @@ mod tests {
     }
 
     #[test]
+    fn test_add_duplicate_ip_to_queue_contributor() {
+        let time = SystemTimeSource::new();
+        let environment = TEST_ENVIRONMENT.clone();
+
+        // Fetch the contributor of the coordinator.
+        let contributor_1 = TEST_CONTRIBUTOR_ID.clone();
+        let contributor_1_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
+        let contributor_2_ip = contributor_1_ip;
+        assert!(contributor_1.is_contributor());
+
+        // Initialize a new coordinator state.
+        let mut state = CoordinatorState::new(environment.clone());
+        assert_eq!(0, state.queue.len());
+
+        // Add the contributors to the coordinator queue.
+        state
+            .add_to_queue(contributor_1.clone(), contributor_1_ip, 10, &time)
+            .unwrap();
+        assert_eq!(1, state.queue.len());
+
+        // Add the second contributor with the same ip and a zeroed reliability score.
+        state
+            .add_to_queue(contributor_2.clone(), contributor_2_ip, 0, &time)
+            .unwrap();
+        assert_eq!(2, state.queue.len());
+
+        // TODO: verify IP is tracked.
+    }
+
+    #[test]
     fn test_add_to_queue_verifier() {
         let time = SystemTimeSource::new();
         let environment = TEST_ENVIRONMENT.clone();

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -3430,9 +3430,9 @@ mod tests {
 
         // Fetch the contributor of the coordinator.
         let contributor_1 = TEST_CONTRIBUTOR_ID.clone();
-        let contributor_1_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
-        let contributor_2_ip = contributor_1_ip;
+        // To be used by both contributors.
+        let contributor_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         assert!(contributor_1.is_contributor());
 
         // Initialize a new coordinator state.
@@ -3441,17 +3441,32 @@ mod tests {
 
         // Add the contributors to the coordinator queue.
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_ip), 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
 
-        // Add the second contributor with the same ip and a zeroed reliability score.
+        // Add the second contributor with the same ip.
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), 0, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_ip), 10, &time)
             .unwrap();
         assert_eq!(2, state.queue.len());
 
-        // TODO: verify IP is tracked.
+        // Check the reliability score has been zeroed for both participants.
+        assert_eq!(0, state.queue.get(&contributor_1).unwrap().0);
+        assert_eq!(0, state.queue.get(&contributor_2).unwrap().0);
+
+        // TODO: work out coordinator state requirements to test this.
+        // Drop one of the participants.
+        // state.drop_participant(&contributor_1, &time).unwrap();
+
+        // Verify the IP still exists as one participant associated with it is left in the queue.
+        // assert!(state.contributor_ips.contains_key(&contributor_ip));
+
+        // Drop the second participant.
+        // state.drop_participant(&contributor_2, &time).unwrap();
+
+        // Verify the IP has been deleted.
+        // assert!(!state.contributor_ips.contains_key(&contributor_ip));
     }
 
     #[test]

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -1526,18 +1526,20 @@ impl CoordinatorState {
             }
         }
 
-        // Zero the reliability score if the participant is joining with a known IP.
-        if let Some(ip) = participant_ip {
-            if self.is_duplicate_ip(&ip) {
-                reliability_score = 0;
+        if !self.environment.disable_reliability_zeroing() {
+            // Zero the reliability score if the participant is joining with a known IP.
+            if let Some(ip) = participant_ip {
+                if self.is_duplicate_ip(&ip) {
+                    reliability_score = 0;
 
-                // Also zero the reliability scores of existing participants in the queue with the
-                // same IP.
-                self.zero_duplicate_ips(&ip);
+                    // Also zero the reliability scores of existing participants in the queue with the
+                    // same IP.
+                    self.zero_duplicate_ips(&ip);
+                }
+                // Map the new IP to the address.
+                let participants = self.contributor_ips.entry(ip).or_insert(HashSet::new());
+                participants.insert(participant.clone());
             }
-            // Map the new IP to the address.
-            let participants = self.contributor_ips.entry(ip).or_insert(HashSet::new());
-            participants.insert(participant.clone());
         }
 
         // Add the participant to the queue.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -3258,7 +3258,15 @@ impl CoordinatorState {
                     *reliability_score = 0;
                 }
 
-                // TODO: update other maps with ParticipantInfo?
+                // Update the current contributors.
+                if let Some(participant_info) = self.current_contributors.get_mut(participant) {
+                    participant_info.reliability = 0;
+                }
+
+                // Update the next contributors.
+                if let Some(participant_info) = self.next.get_mut(participant) {
+                    participant_info.reliability = 0;
+                }
             }
         }
     }

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2123,7 +2123,10 @@ impl CoordinatorState {
             }));
         }
 
-        // Update the IP map.
+        // Update the IP map, there are two cases:
+        // 1. The IP is associated only with the dropped participant, remove it.
+        // 2. The IP associated with the dropped participant is also associated with other participants, in
+        //    which case only remove the first relevant mapping.
         let ips: Vec<_> = self
             .contributor_ips
             .iter()

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -3591,7 +3591,7 @@ mod tests {
 
             // Add a unique contributor.
             let contributor = Participant::Contributor(id.to_string());
-            let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+            let contributor_ip = IpAddr::V4(format!("0.0.0.{}", id).parse().unwrap());
 
             let reliability = 10 - id as u8;
             state

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -260,6 +260,8 @@ pub struct Environment {
     deployment: Deployment,
     /// The base directory for disk storage of this coordinator.
     local_base_directory: String,
+
+    disable_reliability_zeroing: bool,
 }
 
 impl Environment {
@@ -453,6 +455,10 @@ impl Environment {
     pub(crate) fn storage(&self) -> anyhow::Result<Disk> {
         Ok(Disk::load(self)?)
     }
+
+    pub(crate) fn disable_reliability_zeroing(&self) -> bool {
+        self.disable_reliability_zeroing
+    }
 }
 
 impl From<Testing> for Environment {
@@ -579,6 +585,8 @@ impl std::default::Default for Testing {
                 software_version: 1,
                 deployment: Deployment::Testing,
                 local_base_directory: "./transcript/testing".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }
@@ -688,6 +696,8 @@ impl std::default::Default for Development {
                 software_version: 1,
                 deployment: Deployment::Development,
                 local_base_directory: "./transcript/development".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }
@@ -796,6 +806,8 @@ impl std::default::Default for Production {
                 software_version: 1,
                 deployment: Deployment::Production,
                 local_base_directory: "./transcript".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -496,6 +496,11 @@ impl Testing {
         self
     }
 
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
+        self
+    }
+
     #[inline]
     pub fn coordinator_contributors(&self, contributors: &[Participant]) -> Self {
         // Check that all participants are contributors.
@@ -619,6 +624,11 @@ impl Development {
         self
     }
 
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
+        self
+    }
+
     #[inline]
     pub fn coordinator_contributors(&self, contributors: &[Participant]) -> Self {
         // Check that all participants are contributors.
@@ -732,6 +742,11 @@ impl Production {
 
     pub fn queue_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.queue_seen_timeout = timeout;
+        self
+    }
+
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
         self
     }
 

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -113,7 +113,7 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     let (contributor, contributor_signing_key, seed) = create_contributor("1");
     let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor.clone(), contributor_ip, 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -137,7 +137,7 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     // changing the outcome of this test, if necessary.
     //
     let (contributor, _, _) = create_contributor("1");
-    coordinator.add_to_queue(contributor.clone(), contributor_ip, 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Update the ceremony from round 1 to round 2.
@@ -236,10 +236,10 @@ fn coordinator_drop_contributor_basic() {
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
     coordinator
-        .add_to_queue(contributor1.clone(), contributor_1_ip, 10)
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor2.clone(), contributor_2_ip, 9)
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
         .unwrap();
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
@@ -351,9 +351,9 @@ fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
-    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -474,9 +474,9 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
-    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -630,9 +630,9 @@ fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
-    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -790,8 +790,8 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -908,13 +908,13 @@ fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
     coordinator
-        .add_to_queue(contributor1.clone(), contributor_1_ip, 10)
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor2.clone(), contributor_2_ip, 9)
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
         .unwrap();
     coordinator
-        .add_to_queue(contributor3.clone(), contributor_3_ip, 8)
+        .add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)
         .unwrap();
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
@@ -1111,8 +1111,8 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1197,10 +1197,10 @@ fn coordinator_drop_contributor_and_release_locks() {
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 9)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1226,10 +1226,10 @@ fn coordinator_drop_contributor_and_release_locks() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1278,13 +1278,13 @@ fn coordinator_drop_several_contributors() {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 10)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_3.participant.clone(), contributor_3_ip, 10)
+        .add_to_queue(contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1360,10 +1360,10 @@ fn coordinator_drop_several_contributors() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1492,10 +1492,10 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 9)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1521,10 +1521,10 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1569,9 +1569,9 @@ fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
-    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1717,8 +1717,8 @@ fn try_lock_blocked() -> anyhow::Result<()> {
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -1843,8 +1843,8 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     let test_contributor_2 = create_contributor_test_details("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(test_contributor_1.participant.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(test_contributor_2.participant.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(test_contributor_1.participant.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(test_contributor_2.participant.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1885,8 +1885,8 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
-    coordinator.add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)?;
-    coordinator.add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)?;
+    coordinator.add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)?;
+    coordinator.add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)?;
 
     // Update the ceremony to round 2.
     coordinator.update()?;
@@ -1923,8 +1923,8 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2001,7 +2001,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     let (contributor1, _contributor_signing_key1, _seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2064,8 +2064,8 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2137,7 +2137,7 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2203,7 +2203,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     let (contributor1, _, _) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2211,7 +2211,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2269,7 +2269,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     let (contributor1, _, _) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2278,7 +2278,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     let (contributor2, _, _) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2341,7 +2341,7 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -20,6 +20,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
     collections::{HashSet, LinkedList},
     iter::FromIterator,
+    net::{IpAddr, Ipv4Addr},
     sync::Arc,
 };
 
@@ -110,8 +111,9 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
 
     // Meanwhile, add a contributor and verifier to the queue.
     let (contributor, contributor_signing_key, seed) = create_contributor("1");
+    let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor.clone(), 10)?;
+    coordinator.add_to_queue(contributor.clone(), contributor_ip, 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -135,7 +137,7 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     // changing the outcome of this test, if necessary.
     //
     let (contributor, _, _) = create_contributor("1");
-    coordinator.add_to_queue(contributor.clone(), 10)?;
+    coordinator.add_to_queue(contributor.clone(), contributor_ip, 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Update the ceremony from round 1 to round 2.
@@ -229,10 +231,16 @@ fn coordinator_drop_contributor_basic() {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor2.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor1.clone(), contributor_1_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor2.clone(), contributor_2_ip, 9)
+        .unwrap();
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -337,12 +345,15 @@ fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -457,12 +468,15 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -610,12 +624,15 @@ fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -769,10 +786,12 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -882,12 +901,21 @@ fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor2.clone(), 9).unwrap();
-    coordinator.add_to_queue(contributor3.clone(), 8).unwrap();
+    coordinator
+        .add_to_queue(contributor1.clone(), contributor_1_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor2.clone(), contributor_2_ip, 9)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor3.clone(), contributor_3_ip, 8)
+        .unwrap();
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1079,10 +1107,12 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1162,10 +1192,16 @@ fn coordinator_drop_contributor_and_release_locks() {
 
     // Add a contributor and verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 9)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1186,12 +1222,14 @@ fn coordinator_drop_contributor_and_release_locks() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1233,12 +1271,21 @@ fn coordinator_drop_several_contributors() {
 
     // Add some contributors and one verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_3.participant.clone(), 10).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_3.participant.clone(), contributor_3_ip, 10)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1309,12 +1356,14 @@ fn coordinator_drop_several_contributors() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1438,10 +1487,16 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
 
     // Add a contributor and verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), contributor_1_ip, 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), contributor_2_ip, 9)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1462,12 +1517,14 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1506,12 +1563,15 @@ fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), contributor_3_ip, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1653,10 +1713,12 @@ fn try_lock_blocked() -> anyhow::Result<()> {
 
     // Meanwhile, add 2 contributors and 1 verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -1777,10 +1839,12 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let test_contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let test_contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(test_contributor_1.participant.clone(), 10)?;
-    coordinator.add_to_queue(test_contributor_2.participant.clone(), 9)?;
+    coordinator.add_to_queue(test_contributor_1.participant.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(test_contributor_2.participant.clone(), contributor_2_ip, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1818,9 +1882,11 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
-    coordinator.add_to_queue(test_contributor_3.participant.clone(), 10)?;
-    coordinator.add_to_queue(test_contributor_4.participant.clone(), 10)?;
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
+    coordinator.add_to_queue(test_contributor_3.participant.clone(), contributor_3_ip, 10)?;
+    coordinator.add_to_queue(test_contributor_4.participant.clone(), contributor_4_ip, 10)?;
 
     // Update the ceremony to round 2.
     coordinator.update()?;
@@ -1853,10 +1919,12 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1931,8 +1999,9 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _contributor_signing_key1, _seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1991,10 +2060,12 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2064,8 +2135,9 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2129,15 +2201,17 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _, _) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
 
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2193,15 +2267,18 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _, _) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
 
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
+
+    coordinator.add_to_queue(contributor2.clone(), contributor_2_ip, 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2262,8 +2339,9 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), contributor_1_ip, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;


### PR DESCRIPTION
This PR introduces the logic required to move participants using different addresses from the same IP to the back of the queue by `0`ing the reliability score. 

There are a few details I am unsure of:
- Coordinator state in that new test (see todo).
- The drop logic and conditions for which we'd remove participants from the IP list.
- Does `ParticipantInfo` need to be updated in all the maps to reflect the reliability score change (also a todo)?

I'm also unsure of the current process with regards to staging/integration testing so if someone could weigh in on that, that would be much appreciated. 

Coordinator PR: https://github.com/AleoHQ/aleo-setup-coordinator/pull/152