### PR TITLE
Remove the dependency on `chrono`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "setup-utils",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
+ "time 0.3.5",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,15 +301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-humanize"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "ci_info"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,8 +1841,6 @@ name = "phase1-coordinator"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "chrono",
- "chrono-humanize",
  "fs-err",
  "futures",
  "hex",
@@ -2674,7 +2663,6 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
- "chrono",
  "rustversion",
  "serde",
  "serde_with_macros",
@@ -3526,7 +3514,15 @@ checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",
+ "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinystr"

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -19,8 +19,6 @@ setup-utils = { path = "../setup-utils" }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = { version = "1.0.37" }
-chrono = { version = "0.4", features = ["serde"] }
-chrono-humanize = { version = "0.2" }
 fs-err = { version = "2.6.0" }
 itertools = "0.10"
 futures = { version = "0.3" }
@@ -33,9 +31,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde-aux = { version = "3.0" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
-serde_with = { version = "1.8", features = ["chrono", "macros"] }
+serde_with = { version = "1.8", features = ["macros"] }
 thiserror = { version = "1.0" }
-time = { version = "0.3" }
+time = { version = "0.3", features = ["serde-human-readable", "macros"] }
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -35,6 +35,7 @@ serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
 serde_with = { version = "1.8", features = ["chrono", "macros"] }
 thiserror = { version = "1.0" }
+time = { version = "0.3" }
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/phase1-coordinator/src/commands/aggregation.rs
+++ b/phase1-coordinator/src/commands/aggregation.rs
@@ -154,9 +154,9 @@ mod tests {
         Coordinator,
     };
 
-    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
+    use time::OffsetDateTime;
     use tracing::*;
 
     #[test]
@@ -175,7 +175,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
+            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -354,9 +354,9 @@ mod tests {
         Coordinator,
     };
 
-    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
+    use time::OffsetDateTime;
 
     #[test]
     #[serial]
@@ -374,7 +374,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
+            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -2637,11 +2637,10 @@ impl CoordinatorState {
                     let exceeded_chunks_string: String = exceeded_chunk_names.join(", ");
 
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({:?}) allowed time \
+                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
                         it is allowed to hold a lock (on chunks {}).",
                         participant,
-                        participant_lock_timeout,
-                        // chrono_humanize::HumanTime::from(participant_lock_timeout),
+                        participant_lock_timeout.whole_seconds(),
                         exceeded_chunks_string,
                     );
                     Some(self.drop_participant(participant, time))
@@ -2675,12 +2674,11 @@ impl CoordinatorState {
                 // Check if the participant is still live and not a coordinator contributor.
                 if elapsed > contributor_seen_timeout && !self.is_coordinator_contributor(&participant) {
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({:?}) allowed time \
-                        since it was last seen by the coordinator (last seen {:?} ago).",
+                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
+                        since it was last seen by the coordinator (last seen {:?}s ago).",
                         participant,
-                        contributor_seen_timeout,
-                        elapsed // chrono_humanize::HumanTime::from(contributor_seen_timeout),
-                                // chrono_humanize::HumanTime::from(elapsed)
+                        contributor_seen_timeout.whole_seconds(),
+                        elapsed.whole_seconds()
                     );
                     // Drop the participant.
                     Some(self.drop_participant(participant, time))

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -4,7 +4,6 @@ use setup_utils::{CheckForCorrectness, UseCompression};
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use serde_with::DurationSecondsWithFrac;
 
 type BatchSize = usize;
 type ChunkSize = usize;
@@ -225,21 +224,17 @@ pub struct Environment {
     /// Returns the maximum duration a contributor can go without
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    contributor_seen_timeout: chrono::Duration,
+    contributor_seen_timeout: time::Duration,
     /// The maximum duration a verifier can go without being seen by
     /// the coordinator before it will be dropped from the ceremony by
     /// the coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    verifier_seen_timeout: chrono::Duration,
+    verifier_seen_timeout: time::Duration,
     /// The maximum duration a lock can be held by a participant
     /// before it will be dropped from the ceremony by the
     /// coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    participant_lock_timeout: chrono::Duration,
+    participant_lock_timeout: time::Duration,
     /// The maximum duration a queued contributor can go without a heartbeat.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    queue_seen_timeout: chrono::Duration,
+    queue_seen_timeout: time::Duration,
     /// The number of drops tolerated by a participant before banning them from future rounds.
     participant_ban_threshold: u16,
     /// The setting to allow current contributors to join the queue for the next round.
@@ -339,7 +334,7 @@ impl Environment {
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
     ///
-    pub const fn contributor_seen_timeout(&self) -> chrono::Duration {
+    pub const fn contributor_seen_timeout(&self) -> time::Duration {
         self.contributor_seen_timeout
     }
 
@@ -348,7 +343,7 @@ impl Environment {
     /// seen by the coordinator before it will be dropped from the
     /// ceremony by the coordinator.
     ///
-    pub const fn verifier_seen_timeout(&self) -> chrono::Duration {
+    pub const fn verifier_seen_timeout(&self) -> time::Duration {
         self.verifier_seen_timeout
     }
 
@@ -357,7 +352,7 @@ impl Environment {
     /// lock before being dropped from the ceremony by the
     /// coordinator.
     ///
-    pub const fn participant_lock_timeout(&self) -> chrono::Duration {
+    pub const fn participant_lock_timeout(&self) -> time::Duration {
         self.participant_lock_timeout
     }
 
@@ -365,7 +360,7 @@ impl Environment {
     /// Returns the maximum duration that a queued contributor can go
     /// without a heartbeat.
     ///
-    pub const fn queue_seen_timeout(&self) -> chrono::Duration {
+    pub const fn queue_seen_timeout(&self) -> time::Duration {
         self.queue_seen_timeout
     }
 
@@ -525,19 +520,19 @@ impl Testing {
         deployment
     }
 
-    pub fn contributor_seen_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(&self, contributor_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.contributor_seen_timeout = contributor_timeout;
         deployment
     }
 
-    pub fn participant_lock_timeout(&self, participant_lock_timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(&self, participant_lock_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.participant_lock_timeout = participant_lock_timeout;
         deployment
     }
 
-    pub fn queue_seen_timeout(&self, queue_seen_timeout: chrono::Duration) -> Self {
+    pub fn queue_seen_timeout(&self, queue_seen_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.queue_seen_timeout = queue_seen_timeout;
         deployment
@@ -575,10 +570,10 @@ impl std::default::Default for Testing {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::minutes(5),
-                verifier_seen_timeout: chrono::Duration::minutes(15),
-                participant_lock_timeout: chrono::Duration::minutes(20),
-                queue_seen_timeout: chrono::Duration::days(10),
+                contributor_seen_timeout: time::Duration::minutes(5),
+                verifier_seen_timeout: time::Duration::minutes(15),
+                participant_lock_timeout: time::Duration::minutes(20),
+                queue_seen_timeout: time::Duration::days(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -614,12 +609,12 @@ impl Development {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
@@ -691,10 +686,10 @@ impl std::default::Default for Development {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::minutes(1),
-                verifier_seen_timeout: chrono::Duration::minutes(15),
-                participant_lock_timeout: chrono::Duration::minutes(20),
-                queue_seen_timeout: chrono::Duration::minutes(10),
+                contributor_seen_timeout: time::Duration::minutes(1),
+                verifier_seen_timeout: time::Duration::minutes(15),
+                participant_lock_timeout: time::Duration::minutes(20),
+                queue_seen_timeout: time::Duration::minutes(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -730,17 +725,17 @@ impl Production {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
 
-    pub fn queue_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn queue_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.queue_seen_timeout = timeout;
         self
     }
@@ -806,10 +801,10 @@ impl std::default::Default for Production {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::days(7),
-                verifier_seen_timeout: chrono::Duration::days(7),
-                participant_lock_timeout: chrono::Duration::days(7),
-                queue_seen_timeout: chrono::Duration::days(7),
+                contributor_seen_timeout: time::Duration::days(7),
+                verifier_seen_timeout: time::Duration::days(7),
+                participant_lock_timeout: time::Duration::days(7),
+                queue_seen_timeout: time::Duration::days(7),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: false,
                 allow_current_verifiers_in_queue: true,

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -15,12 +15,12 @@ use crate::{
     CoordinatorError,
 };
 
-use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::*;
 use serde_diff::SerdeDiff;
 use std::{collections::HashSet, hash::Hash};
+use time::OffsetDateTime;
 use tracing::{debug, error, trace, warn};
 
 use super::Task;
@@ -74,9 +74,9 @@ pub struct Round {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     height: u64,
     #[serde_diff(opaque)]
-    started_at: Option<DateTime<Utc>>,
+    started_at: Option<OffsetDateTime>,
     #[serde_diff(opaque)]
-    finished_at: Option<DateTime<Utc>>,
+    finished_at: Option<OffsetDateTime>,
     contributor_ids: Vec<Participant>,
     verifier_ids: Vec<Participant>,
     chunks: Vec<Chunk>,
@@ -89,7 +89,7 @@ impl Round {
         environment: &Environment,
         storage: &mut Disk,
         round_height: u64,
-        started_at: DateTime<Utc>,
+        started_at: OffsetDateTime,
         contributor_ids: Vec<Participant>,
     ) -> Result<Self, CoordinatorError> {
         debug!("Starting to create round {}", round_height);
@@ -758,7 +758,7 @@ impl Round {
 
         // If all chunks are complete and the finished at timestamp has not been set yet,
         // then set it with the current UTC timestamp.
-        self.try_finish(Utc::now());
+        self.try_finish(OffsetDateTime::now_utc());
 
         Ok(())
     }
@@ -1094,7 +1094,7 @@ impl Round {
     /// then set it with the current UTC timestamp.
     ///
     #[inline]
-    pub(crate) fn try_finish(&mut self, timestamp: DateTime<Utc>) {
+    pub(crate) fn try_finish(&mut self, timestamp: OffsetDateTime) {
         if self.is_complete() && self.finished_at.is_none() {
             self.finished_at = Some(timestamp);
         }
@@ -1105,7 +1105,7 @@ impl Round {
     ///
     #[cfg(test)]
     #[inline]
-    pub(crate) fn try_finish_testing_only_unsafe(&mut self, timestamp: DateTime<Utc>) {
+    pub(crate) fn try_finish_testing_only_unsafe(&mut self, timestamp: OffsetDateTime) {
         if self.is_complete() {
             warn!("Modifying finished_at timestamp for testing only");
             self.finished_at = Some(timestamp);

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -74,8 +74,10 @@ pub struct Round {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     height: u64,
     #[serde_diff(opaque)]
+    #[serde(with = "time::serde::timestamp::option")]
     started_at: Option<OffsetDateTime>,
     #[serde_diff(opaque)]
+    #[serde(with = "time::serde::timestamp::option")]
     finished_at: Option<OffsetDateTime>,
     contributor_ids: Vec<Participant>,
     verifier_ids: Vec<Participant>,

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -7,12 +7,12 @@ use crate::{
     CoordinatorError,
 };
 
-use chrono::{DateTime, TimeZone, Utc};
 use once_cell::sync::Lazy;
 use serde_diff::{Diff, SerdeDiff};
 #[cfg(test)]
 use serial_test::serial;
 use std::{path::Path, sync::Arc};
+use time::{macros::datetime, OffsetDateTime};
 use tracing::*;
 
 use fs_err as fs;
@@ -27,7 +27,7 @@ pub static TEST_ENVIRONMENT: Lazy<Environment> = Lazy::new(|| Testing::from(Para
 pub static TEST_ENVIRONMENT_3: Lazy<Environment> = Lazy::new(|| Testing::from(Parameters::Test3Chunks).into());
 
 /// Round start datetime for testing purposes only.
-pub static TEST_STARTED_AT: Lazy<DateTime<Utc>> = Lazy::new(|| Utc.ymd(1970, 1, 1).and_hms(0, 1, 1));
+pub static TEST_STARTED_AT: Lazy<OffsetDateTime> = Lazy::new(|| datetime!(1970-01-01 00:01:01 UTC));
 
 /// Contributor ID for testing purposes only.
 pub static TEST_CONTRIBUTOR_ID: Lazy<Participant> =

--- a/phase1-coordinator/src/testing/resources/round.json
+++ b/phase1-coordinator/src/testing/resources/round.json
@@ -1,7 +1,7 @@
 {
     "version": 0,
     "height": 0,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [
         "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",

--- a/phase1-coordinator/src/testing/resources/test_round_0.json
+++ b/phase1-coordinator/src/testing/resources/test_round_0.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 0,
     "timestamp": null,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [],
     "verifierIds": [],

--- a/phase1-coordinator/src/testing/resources/test_round_1_initial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_initial.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 1,
     "timestamp": null,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [
         "testing-coordinator-contributor.contributor"

--- a/phase1-coordinator/src/testing/resources/test_round_1_partial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_partial.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "height": 1,
-  "startedAt": "2021-06-22T17:25:21.109306563Z",
+  "startedAt": 1624382721,
   "finishedAt": null,
   "contributorIds": [
     "testing-coordinator-contributor-3.contributor",

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -11,8 +11,8 @@ use crate::{
     Participant,
     Round,
 };
-use chrono::Utc;
 use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
+use time::OffsetDateTime;
 
 use fs_err as fs;
 use rand::RngCore;
@@ -1975,7 +1975,7 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -1987,8 +1987,8 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(5))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(5))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2011,14 +2011,14 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // contributor to timeout)
-    time.update(|prev| prev + chrono::Duration::minutes(1));
+    time.update(|prev| prev + time::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::minutes(5));
+    time.update(|prev| prev + time::Duration::minutes(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2036,7 +2036,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_wait_verifier_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2047,8 +2047,8 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
         16, /* chunk_size */
     ));
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(5))
-        .participant_lock_timeout(chrono::Duration::minutes(8));
+        .contributor_seen_timeout(time::Duration::minutes(5))
+        .participant_lock_timeout(time::Duration::minutes(8));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
     let number_of_chunks = environment.number_of_chunks() as usize;
@@ -2071,7 +2071,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     coordinator.update()?;
 
     for _ in 0..(number_of_chunks / 2) {
-        time.update(|prev| prev + chrono::Duration::minutes(1));
+        time.update(|prev| prev + time::Duration::minutes(1));
         coordinator.contribute(&contributor1, &contributor_signing_key1, &seed1)?;
         coordinator.contribute(&contributor2, &contributor_signing_key2, &seed2)?;
     }
@@ -2085,7 +2085,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 
     // contributors are stuck waiting for 10 minutes, longer than the
     // contributor timeout duration.
-    time.update(|prev| prev + chrono::Duration::minutes(10));
+    time.update(|prev| prev + time::Duration::minutes(10));
 
     // Emulate contributor querying the current round via the
     // `/v1/round/current` endpoint.
@@ -2111,7 +2111,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2123,8 +2123,8 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(20))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(20))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2151,14 +2151,14 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::minutes(1));
+    time.update(|prev| prev + time::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::minutes(10));
+    time.update(|prev| prev + time::Duration::minutes(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2177,7 +2177,7 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2189,8 +2189,8 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::days(20))
-        .participant_lock_timeout(chrono::Duration::days(20));
+        .contributor_seen_timeout(time::Duration::days(20))
+        .participant_lock_timeout(time::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2219,7 +2219,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
@@ -2227,7 +2227,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::days(10));
+    time.update(|prev| prev + time::Duration::days(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2243,7 +2243,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2255,8 +2255,8 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::days(20))
-        .participant_lock_timeout(chrono::Duration::days(20));
+        .contributor_seen_timeout(time::Duration::days(20))
+        .participant_lock_timeout(time::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2286,7 +2286,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     // Send heartbeat from contributor2
@@ -2297,7 +2297,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2315,7 +2315,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn rollback_locked_chunk() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2327,8 +2327,8 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(20))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(20))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 


### PR DESCRIPTION
Supersedes #434 for the `chrono` failure.

Drafted as the tests still need some fixing. 