### PR TITLE
Realign `phase2` with `master`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
 
 [[package]]
 name = "arrayref"
@@ -251,12 +251,6 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -267,7 +261,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "zeroize",
@@ -298,15 +292,6 @@ dependencies = [
  "serde",
  "time 0.1.43",
  "winapi",
-]
-
-[[package]]
-name = "chrono-humanize"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
-dependencies = [
- "chrono",
 ]
 
 [[package]]
@@ -363,7 +348,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -452,7 +437,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -466,7 +451,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -476,7 +461,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -487,7 +472,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -500,7 +485,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -510,7 +495,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -568,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
+checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
 dependencies = [
  "curl-sys",
  "libc",
@@ -583,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.50+curl-7.79.1"
+version = "0.4.51+curl-7.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
+checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
 dependencies = [
  "cc",
  "libc",
@@ -685,7 +670,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_cpus",
 ]
 
@@ -779,7 +764,7 @@ version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -889,16 +874,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -911,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -921,15 +900,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -938,18 +917,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -957,23 +934,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -983,8 +959,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -998,16 +972,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generator"
-version = "0.6.25"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061d3be1afec479d56fa3bd182bf966c7999ec175fcfdb87ac14d417241366c6"
+checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
 dependencies = [
  "cc",
  "libc",
@@ -1041,7 +1009,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1052,7 +1020,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
@@ -1193,15 +1161,15 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1348,7 +1316,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1409,9 +1377,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libz-sys"
@@ -1453,18 +1421,20 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "loom"
-version = "0.3.6"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+checksum = "5df2c4aeb432e60c9e5ae517ca8ed8b63556ce23093b2758fc8837d75439c5ec"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "generator",
  "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1582,7 +1552,7 @@ checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -1690,9 +1660,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "oneshot"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d7085e4e51b36df4afa83db60d20ad2adf8e8587a193f93c9143bf7b375dec"
+checksum = "f3b8d98df258e762e901eb4349d66d5a5f5a7a994db8df82ff596011773be535"
 dependencies = [
  "loom",
 ]
@@ -1716,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1731,9 +1701,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.70"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg",
  "cc",
@@ -1765,7 +1735,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -1803,7 +1773,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "criterion",
  "derivative",
  "itertools",
@@ -1850,8 +1820,6 @@ name = "phase1-coordinator"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "chrono",
- "chrono-humanize",
  "fs-err",
  "futures",
  "hex",
@@ -1870,6 +1838,7 @@ dependencies = [
  "setup-utils",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
+ "time 0.3.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1881,7 +1850,7 @@ version = "0.3.0"
 dependencies = [
  "blake2",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "console_error_panic_hook",
  "getrandom 0.2.3",
  "hex",
@@ -1930,7 +1899,7 @@ name = "phase2"
 version = "0.3.0"
 dependencies = [
  "byteorder",
- "cfg-if 1.0.0",
+ "cfg-if",
  "console_error_panic_hook",
  "crossbeam",
  "hex",
@@ -2085,18 +2054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,29 +2069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
 ]
 
 [[package]]
@@ -2181,21 +2115,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2265,15 +2184,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2366,19 +2276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time 0.1.43",
-]
-
-[[package]]
 name = "rust-embed"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,12 +2314,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
@@ -2646,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -2673,7 +2564,6 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
- "chrono",
  "rustversion",
  "serde",
  "serde_with_macros",
@@ -2719,7 +2609,7 @@ version = "0.3.0"
 dependencies = [
  "blake2",
  "blake2s_simd",
- "cfg-if 1.0.0",
+ "cfg-if",
  "criterion",
  "crossbeam",
  "futures",
@@ -2730,9 +2620,9 @@ dependencies = [
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "rayon",
- "rust-crypto",
  "rusty-hook",
  "serde",
+ "sha2",
  "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
@@ -2851,7 +2741,7 @@ name = "setup2"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fs-err",
  "gumdrop",
  "hex",
@@ -2879,7 +2769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2892,7 +2782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -3312,7 +3202,7 @@ version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fxhash",
  "indexmap",
  "itertools",
@@ -3328,7 +3218,7 @@ version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c#fc997c3e99ecc42d30e31302b4550001ccf86f5a"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fxhash",
  "indexmap",
  "itertools",
@@ -3424,9 +3314,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3451,7 +3341,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand 0.8.4",
  "redox_syscall",
@@ -3525,7 +3415,15 @@ checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",
+ "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinystr"
@@ -3560,9 +3458,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3579,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3648,7 +3546,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3698,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
+checksum = "7507ec620f809cdf07cccb5bc57b13069a88031b795efd4079b1c71b66c1613d"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
@@ -3899,7 +3797,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3926,7 +3824,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,74 +3,69 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "age"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d68559c3ef40bc0fd7c3d2b156743e9387d477a68733b61dff0f6a5004ad58"
+checksum = "cf320f937ccd0eb7f63450be0f071586cd918cd86785303ec1d052a3e243b550"
 dependencies = [
  "age-core",
  "base64",
  "bech32",
- "c2-chacha",
  "chacha20poly1305",
  "console",
  "cookie-factory",
  "hkdf",
  "hmac",
- "i18n-embed 0.12.1",
+ "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
  "nom",
  "pin-project",
  "pinentry",
  "rand 0.7.3",
+ "rand 0.8.4",
  "rpassword",
  "rust-embed",
  "scrypt",
- "secrecy",
  "sha2",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "age-core"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad65fc4325804de2e915f5a50dda38218ed49f97e1270750acef9ff8bb67ac36"
+checksum = "a485102f6c7a23e0666b169ba77c9ff6c6d249c05395c379be3cbab48a948e84"
 dependencies = [
  "base64",
- "c2-chacha",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
  "nom",
- "rand 0.7.3",
+ "rand 0.8.4",
  "secrecy",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -79,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -106,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arrayref"
@@ -168,21 +163,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -223,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -235,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -252,16 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "c2-chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6002dbb7c65a76e516625443949a8b7bb0d0845fe6a3dc39e2dd7ae39dcb9c"
-dependencies = [
- "cipher 0.2.5",
- "ppv-lite86",
-]
-
-[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -289,13 +262,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chacha20poly1305"
-version = "0.7.1"
+name = "chacha20"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
 dependencies = [
  "aead",
- "cipher 0.2.5",
+ "chacha20",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -310,7 +296,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -330,15 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
 dependencies = [
  "envmnt",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -367,13 +344,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "regex",
  "terminal_size",
  "unicode-width",
@@ -382,11 +359,11 @@ dependencies = [
 
 [[package]]
 name = "console_error_panic_hook"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -410,9 +387,9 @@ checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -420,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -432,12 +409,6 @@ checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "criterion"
@@ -587,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix",
  "winapi",
@@ -597,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003cb79c1c6d1c93344c7e1201bb51c2148f24ec2bd9c253709d6b2efb796515"
+checksum = "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
 dependencies = [
  "curl-sys",
  "libc",
@@ -612,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.48+curl-7.79.1"
+version = "0.4.50+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a77a741f832116da66aeb126b4f19190ecf46144a74a9bde43c2086f38da0e"
+checksum = "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
 dependencies = [
  "cc",
  "libc",
@@ -744,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+checksum = "61579ada4ec0c6031cfac3f86fdba0d195a7ebeb5e36693bd53cb5999a25beeb"
 dependencies = [
  "console",
  "lazy_static",
@@ -804,9 +775,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -832,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4d7142005e2066e4844caf9f271b93fc79836ee96ec85057b8c109687e629a"
+checksum = "61f69378194459db76abd2ce3952b790db103ceb003008d3d50d97c41ff847a7"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -842,16 +813,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acf044eeb4872d9dbf2667541fbf461f5965c57e343878ad0fb24b5793fa007"
+checksum = "e242c601dec9711505f6d5bbff5bedd4b61b2469f2e8bb8e57ee7c9747a87ffd"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "ouroboros",
  "rustc-hash",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -922,12 +893,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1039,6 +1004,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "generator"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061d3be1afec479d56fa3bd182bf966c7999ec175fcfdb87ac14d417241366c6"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes",
  "fnv",
@@ -1122,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -1161,9 +1139,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hkdf"
@@ -1198,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -1221,9 +1199,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1272,24 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.9.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d31ac705e9fe3e7d3fcb3fe23882118f858383c65a7ddba2cfe80f6fa5cd760"
-dependencies = [
- "fluent-langneg",
- "lazy_static",
- "locale_config",
- "log",
- "rust-embed",
- "thiserror",
- "unic-langid",
-]
-
-[[package]]
-name = "i18n-embed"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3794c3d7fea43e076281c9213cfaaa7a53c3f18b1613f12514b9f575a2908457"
+checksum = "d8be76966dc82fc0c1fe50bac057170294594ab2a78a0e5d82f85227248a19a1"
 dependencies = [
  "fluent",
  "fluent-langneg",
@@ -1297,6 +1260,7 @@ dependencies = [
  "i18n-embed-impl",
  "intl-memoizer",
  "lazy_static",
+ "locale_config",
  "log",
  "parking_lot",
  "rust-embed",
@@ -1307,16 +1271,16 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91f4951bd0bc19624a06781bf8cd05bdd59057622e5d4240823b42a5f102d2"
+checksum = "f62d90f2e4a28030550e338f920d84666c8a9d59849c16e96fec4beb79e73c33"
 dependencies = [
  "dashmap",
  "find-crate",
  "fluent",
  "fluent-syntax",
  "i18n-config",
- "i18n-embed 0.12.1",
+ "i18n-embed",
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
@@ -1328,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-impl"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2757ae6d1dd47fba009e86795350186fc4740a6e53a1b4f336a8a6725d20eb53"
+checksum = "0db2330e035808eb064afb67e6743ddce353763af3e0f2bdfc2476e00ce76136"
 dependencies = [
  "find-crate",
  "i18n-config",
@@ -1368,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
  "lazy_static",
@@ -1380,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1445,9 +1409,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libz-sys"
@@ -1493,6 +1457,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -1518,9 +1493,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap"
@@ -1548,10 +1523,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mio"
-version = "0.7.13"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1595,9 +1576,9 @@ checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -1608,13 +1589,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -1629,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1669,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc"
@@ -1709,6 +1689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "oneshot"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d7085e4e51b36df4afa83db60d20ad2adf8e8587a193f93c9143bf7b375dec"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,9 +1711,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1742,38 +1731,15 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ouroboros"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeff60e3e37407a80ead3e9458145b456e978c4068cddbfea6afb48572962ca"
-dependencies = [
- "ouroboros_macro",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1809,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
 dependencies = [
  "crypto-mac 0.11.1",
 ]
@@ -1841,6 +1807,7 @@ dependencies = [
  "criterion",
  "derivative",
  "itertools",
+ "memmap",
  "num-traits",
  "phase1",
  "rand 0.8.4",
@@ -1849,14 +1816,14 @@ dependencies = [
  "rusty-hook",
  "serde",
  "setup-utils",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-ledger",
- "snarkvm-marlin",
- "snarkvm-polycommit",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-marlin 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "tracing",
 ]
 
@@ -1872,7 +1839,7 @@ dependencies = [
  "rand 0.8.4",
  "rustc_version 0.4.0",
  "setup-utils",
- "snarkvm-curves",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen-test",
@@ -1901,7 +1868,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "setup-utils",
- "snarkvm-curves",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
  "tokio",
  "tracing",
@@ -1912,21 +1879,50 @@ dependencies = [
 name = "phase1-wasm"
 version = "0.3.0"
 dependencies = [
+ "blake2",
+ "bytes",
+ "cfg-if 1.0.0",
  "console_error_panic_hook",
  "getrandom 0.2.3",
+ "hex",
+ "http",
+ "js-sys",
+ "oneshot",
  "phase1",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
- "rustc_version 0.3.3",
+ "rayon",
+ "rayon-core",
+ "reqwest",
+ "rustc_version 0.4.0",
  "serde",
+ "serde-diff",
  "serde_derive",
+ "serde_json",
  "setup-utils",
- "snarkvm-curves",
- "snarkvm-fields",
+ "setup1-shared",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
+name = "phase1-wasm-keys"
+version = "0.1.0"
+dependencies = [
+ "blake2",
+ "getrandom 0.2.3",
+ "hex",
+ "rand 0.8.4",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1946,11 +1942,11 @@ dependencies = [
  "rayon",
  "rusty-hook",
  "setup-utils",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
@@ -1992,9 +1988,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinentry"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8266a6e77c40ef16f3d00bfe72ddb6e2fd29384d5b87e6bae1975099aa12921"
+checksum = "bfa5b8bc68be6a5e2ba84ee86db53f816cba1905b94fcb7c236e606221cc8fc8"
 dependencies = [
  "log",
  "nom",
@@ -2006,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "plotters"
@@ -2040,19 +2036,20 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpuid-bool",
+ "cpufeatures",
+ "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2101,27 +2098,21 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -2296,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2331,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64",
  "bytes",
@@ -2353,6 +2344,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
@@ -2383,14 +2375,14 @@ dependencies = [
  "libc",
  "rand 0.3.23",
  "rustc-serialize",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "5.9.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe1fe6aac5d6bb9e1ffd81002340363272a7648234ec7bdfac5ee202cb65523"
+checksum = "1be44a6694859b7cfc955699935944a6844aa9fe416aeda5d40829e3e38dfee6"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2399,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "5.9.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed91c41c42ef7bf687384439c312e75e0da9c149b0390889b94de3c7d9d9e66"
+checksum = "f567ca01565c50c67b29e535f5f67b8ea8aeadaeed16a88f10792ab57438b957"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2412,10 +2404,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "5.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d"
+checksum = "6116e7ab9ea963f60f2f20291d8fcf6c7273192cdd7273b3c80729a9605c97b2"
 dependencies = [
+ "sha2",
  "walkdir",
 ]
 
@@ -2479,7 +2472,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -2515,9 +2508,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879588d8f90906e73302547e20fffefdd240eb3e0e744e142321f5d49dea0518"
+checksum = "9f2cc535b6997b0c755bf9344e71ca0e1be070d07ff792f1fcd31e7b90e07d5f"
 dependencies = [
  "hmac",
  "pbkdf2",
@@ -2527,18 +2520,18 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2556,6 +2549,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac753e6625df1711012c6469644ddd9b6338be1e4abf235c3a8817191411ae1"
 
 [[package]]
 name = "semver"
@@ -2592,13 +2591,12 @@ dependencies = [
 
 [[package]]
 name = "serde-aux"
-version = "0.6.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae50f53d4b01e854319c1f5b854cd59471f054ea7e554988850d3f36ca1dc852"
+checksum = "93abf9799c576f004252b2a05168d58527fb7c54de12e94b4d12fe3475ffad24"
 dependencies = [
  "chrono",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
@@ -2648,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2671,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
  "chrono",
  "rustversion",
@@ -2683,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
  "darling 0.13.0",
  "proc-macro2",
@@ -2724,7 +2722,11 @@ dependencies = [
  "cfg-if 1.0.0",
  "criterion",
  "crossbeam",
+<<<<<<< HEAD
  "generic-array",
+=======
+ "futures",
+>>>>>>> master
  "hex",
  "num_cpus",
  "phase1",
@@ -2734,11 +2736,11 @@ dependencies = [
  "rust-crypto",
  "rusty-hook",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
  "tracing",
 ]
@@ -2754,7 +2756,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "snarkvm-dpc",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "structopt",
  "unic-langid",
 ]
@@ -2774,7 +2776,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http",
- "i18n-embed 0.9.4",
+ "i18n-embed",
  "indicatif",
  "panic-control",
  "phase1",
@@ -2789,9 +2791,9 @@ dependencies = [
  "serial_test",
  "setup-utils",
  "setup1-shared",
- "snarkvm-curves",
- "snarkvm-dpc",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "structopt",
  "thiserror",
  "tokio",
@@ -2811,7 +2813,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setup-utils",
- "snarkvm-curves",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "tokio",
 ]
 
@@ -2820,7 +2822,6 @@ name = "setup1-verifier"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "chrono",
  "ctrlc",
  "fs-err",
  "futures-util",
@@ -2836,10 +2837,10 @@ dependencies = [
  "serde_json",
  "setup-utils",
  "setup1-shared",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-dpc",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "structopt",
  "thiserror",
  "tokio",
@@ -2863,13 +2864,13 @@ dependencies = [
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "setup-utils",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-dpc",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-parameters 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
  "tracing-subscriber",
 ]
@@ -2902,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -2920,15 +2921,42 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "blake2s_simd",
+ "crossbeam-channel",
+ "derivative",
+ "digest",
+ "itertools",
+ "lazy_static",
+ "once_cell",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "sha2",
+ "smallvec",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "thiserror",
+]
 
 [[package]]
 name = "snarkvm-algorithms"
@@ -2949,11 +2977,26 @@ dependencies = [
  "rayon",
  "sha2",
  "smallvec",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-profiler",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "derivative",
+ "rand 0.8.4",
+ "rand_xorshift",
+ "rustc_version 0.4.0",
+ "serde",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "thiserror",
 ]
 
@@ -2967,9 +3010,21 @@ dependencies = [
  "rand_xorshift",
  "rustc_version 0.4.0",
  "serde",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
+]
+
+[[package]]
+name = "snarkvm-derives"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2982,6 +3037,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "snarkvm-dpc"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "anyhow",
+ "base58",
+ "bech32",
+ "bincode",
+ "blake2",
+ "derivative",
+ "hex",
+ "itertools",
+ "once_cell",
+ "rand 0.8.4",
+ "serde",
+ "sha2",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-marlin 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-parameters 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "thiserror",
 ]
 
 [[package]]
@@ -3001,16 +3086,31 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "sha2",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-gadgets",
- "snarkvm-marlin",
- "snarkvm-parameters",
- "snarkvm-polycommit",
- "snarkvm-profiler",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-marlin 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-parameters 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derivative",
+ "rand 0.8.4",
+ "rand_xorshift",
+ "serde",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "thiserror",
 ]
 
@@ -3025,7 +3125,26 @@ dependencies = [
  "rand 0.8.4",
  "rand_xorshift",
  "serde",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-gadgets"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "thiserror",
 ]
 
@@ -3040,11 +3159,11 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
 ]
 
@@ -3062,18 +3181,40 @@ dependencies = [
  "parking_lot",
  "rand 0.8.4",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-dpc",
- "snarkvm-fields",
- "snarkvm-gadgets",
- "snarkvm-marlin",
- "snarkvm-parameters",
- "snarkvm-polycommit",
- "snarkvm-profiler",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-marlin 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-parameters 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
+]
+
+[[package]]
+name = "snarkvm-marlin"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "blake2",
+ "derivative",
+ "digest",
+ "hashbrown",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
 ]
 
 [[package]]
@@ -3089,14 +3230,25 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "rayon",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-gadgets",
- "snarkvm-polycommit",
- "snarkvm-profiler",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-polycommit 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "hex",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "thiserror",
 ]
 
 [[package]]
@@ -3106,9 +3258,27 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c#fc997c3e99ecc42d3
 dependencies = [
  "curl",
  "hex",
- "snarkvm-algorithms",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
+]
+
+[[package]]
+name = "snarkvm-polycommit"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "derivative",
+ "digest",
+ "hashbrown",
+ "rand_core 0.6.3",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
 ]
 
 [[package]]
@@ -3120,19 +3290,40 @@ dependencies = [
  "digest",
  "hashbrown",
  "rand_core 0.6.3",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-gadgets",
- "snarkvm-profiler",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-gadgets 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-profiler 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
 ]
 
 [[package]]
 name = "snarkvm-profiler"
 version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+
+[[package]]
+name = "snarkvm-profiler"
+version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c#fc997c3e99ecc42d30e31302b4550001ccf86f5a"
+
+[[package]]
+name = "snarkvm-r1cs"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "fxhash",
+ "indexmap",
+ "itertools",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "thiserror",
+]
 
 [[package]]
 name = "snarkvm-r1cs"
@@ -3144,9 +3335,22 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm#137b57a3bc0a3a5f3e8e8e8300f748990a77bdeb"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "num-bigint",
+ "rand 0.8.4",
+ "snarkvm-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "thiserror",
 ]
 
@@ -3159,7 +3363,7 @@ dependencies = [
  "bincode",
  "num-bigint",
  "rand 0.8.4",
- "snarkvm-derives",
+ "snarkvm-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
 ]
 
@@ -3172,12 +3376,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -3199,9 +3397,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3210,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3229,9 +3427,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3240,21 +3438,15 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3291,18 +3483,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3329,6 +3521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa",
+ "libc",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3361,9 +3563,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3380,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3402,7 +3604,8 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.15.0"
-source = "git+https://github.com/snapview/tokio-tungstenite?rev=2bfd4cd#2bfd4cd0f59e05d65235422d4a24cf133da45797"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
@@ -3415,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3444,9 +3647,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -3456,20 +3659,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
- "chrono",
  "crossbeam-channel",
+ "time 0.3.5",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3478,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -3497,35 +3700,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.24"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time 0.3.5",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -3536,9 +3726,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d40747bce878d2fb67d910dcb8bd3eca2b2358540c3cc1b98c027407a3ae3"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64",
  "byteorder",
@@ -3596,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -3860,16 +4050,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wsl"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -3878,18 +4068,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,11 +2722,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "criterion",
  "crossbeam",
-<<<<<<< HEAD
- "generic-array",
-=======
  "futures",
->>>>>>> master
+ "generic-array",
  "hex",
  "num_cpus",
  "phase1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "phase1-cli",
     "phase1-coordinator",
     "phase1-wasm",
+    "phase1-wasm-keys",
     "phase2",
     "setup1-cli-tools",
     "setup1-contributor",
@@ -16,7 +17,7 @@ members = [
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = true
 incremental = true
 
 [profile.bench]

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -19,7 +19,7 @@ hex = { version = "0.4.2" }
 memmap = { version = "0.7.0" }
 rand = { version = "0.8" }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.2" }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.18" }

--- a/phase1-cli/README.md
+++ b/phase1-cli/README.md
@@ -13,7 +13,7 @@ Coordinators run:
 
 Users should only care about the `contribute` option.
 
-```ignore
+```text
 $ ./phase1 --help
 Usage: ./phase1 [OPTIONS]
 
@@ -40,7 +40,7 @@ Available commands:
 This binary will only be run by the coordinator after Phase 1 has been executed.
 Note that the parameters produced are **only for the Groth16 SNARK**.
 
-```ignore
+```text
 ./prepare_phase2 --help
 Usage: ./prepare_phase2 [OPTIONS]
 
@@ -64,8 +64,8 @@ Optional arguments:
 
 This work is licensed under either of the following licenses, at your discretion.
 
-- Apache License Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+- Apache License Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
 as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/phase1-cli/scripts/phase1_chunked.sh
+++ b/phase1-cli/scripts/phase1_chunked.sh
@@ -11,7 +11,7 @@ if [ "$PROVING_SYSTEM" == "groth16" ]; then
 else
   MAX_CHUNK_INDEX=1 # we have 2 chunks, since we have a total of 2^11-1 powers
 fi
-CURVE="bw6"
+CURVE="bls12_377"
 SEED1=`tr -dc 'A-F0-9' < /dev/random | head -c32`
 echo $SEED1 > seed1
 SEED2=`tr -dc 'A-F0-9' < /dev/random | head -c32`

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -16,7 +16,7 @@ use gumdrop::Options;
 use std::{fs::read_to_string, process, time::Instant};
 use tracing_subscriber::{
     filter::EnvFilter,
-    fmt::{time::ChronoUtc, Subscriber},
+    fmt::{time, Subscriber},
 };
 
 const CHALLENGE_IS_COMPRESSED: UseCompression = UseCompression::No;
@@ -104,7 +104,7 @@ fn execute_cmd<E: Engine>(opts: Phase1Opts) {
 fn main() {
     Subscriber::builder()
         .with_target(false)
-        .with_timer(ChronoUtc::rfc3339())
+        .with_timer(time::UtcTime::rfc_3339())
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 

--- a/phase1-cli/src/bin/prepare_phase2.rs
+++ b/phase1-cli/src/bin/prepare_phase2.rs
@@ -12,7 +12,7 @@ use memmap::*;
 use std::{fs::OpenOptions, time::Instant};
 use tracing_subscriber::{
     filter::EnvFilter,
-    fmt::{time::ChronoUtc, Subscriber},
+    fmt::{time, Subscriber},
 };
 
 #[derive(Debug, Options, Clone)]
@@ -94,7 +94,7 @@ fn prepare_phase2<E: Engine + Sync>(opts: &PreparePhase2Opts) -> Result<()> {
 
 fn main() -> Result<()> {
     Subscriber::builder()
-        .with_timer(ChronoUtc::rfc3339())
+        .with_timer(time::UtcTime::rfc_3339())
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -1,6 +1,5 @@
 // Documentation
-#![cfg_attr(nightly, feature(doc_cfg, external_doc))]
-#![cfg_attr(nightly, doc(include = "../README.md"))]
+#![doc = include_str!("../README.md")]
 
 mod combine;
 pub use combine::combine;

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -19,8 +19,6 @@ setup-utils = { path = "../setup-utils" }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = { version = "1.0.37" }
-chrono = { version = "0.4", features = ["serde"] }
-chrono-humanize = { version = "0.2" }
 fs-err = { version = "2.6.0" }
 itertools = "0.10"
 futures = { version = "0.3" }
@@ -33,8 +31,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde-aux = { version = "3.0" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
-serde_with = { version = "1.8", features = ["chrono", "macros"] }
+serde_with = { version = "1.8", features = ["macros"] }
 thiserror = { version = "1.0" }
+time = { version = "0.3", features = ["serde-human-readable", "macros"] }
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -30,21 +30,21 @@ once_cell = { version = "1.5.2" }
 rand = { version = "0.8" }
 rayon = { version = "1.4.1" }
 serde = { version = "1.0", features = ["derive"] }
-serde-aux = { version = "0.6" }
+serde-aux = { version = "3.0" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
 serde_with = { version = "1.8", features = ["chrono", "macros"] }
 thiserror = { version = "1.0" }
-tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.2" }
+tracing-subscriber = { version = "0.3" }
 
 [dev-dependencies]
 serial_test = { version = "0.5" }
-tracing-subscriber = { version = "0.2" }
+tracing-subscriber = { version = "0.3" }
 
 [features]
 default = []
-operator = ["testing"]
+operator = ["testing", "setup-utils/cli"]
 parallel = ["phase1/parallel", "setup-utils/parallel"]
 testing = []

--- a/phase1-coordinator/src/commands/aggregation.rs
+++ b/phase1-coordinator/src/commands/aggregation.rs
@@ -154,9 +154,9 @@ mod tests {
         Coordinator,
     };
 
-    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
+    use time::OffsetDateTime;
     use tracing::*;
 
     #[test]
@@ -175,7 +175,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
+            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -354,9 +354,9 @@ mod tests {
         Coordinator,
     };
 
-    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
+    use time::OffsetDateTime;
 
     #[test]
     #[serial]
@@ -374,7 +374,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
+            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -30,12 +30,12 @@ use crate::{
 };
 use setup_utils::calculate_hash;
 
-use chrono::{DateTime, Utc};
 use std::{
     fmt,
     net::IpAddr,
     sync::{Arc, RwLock},
 };
+use time::OffsetDateTime;
 use tracing::*;
 
 #[cfg(any(test, feature = "operator"))]
@@ -278,7 +278,7 @@ impl From<CoordinatorError> for anyhow::Error {
 /// for mocking system time during testing.
 pub trait TimeSource: Send + Sync {
     /// Provide the current time now in the UTC timezone
-    fn utc_now(&self) -> DateTime<Utc>;
+    fn now_utc(&self) -> OffsetDateTime;
 }
 
 // Private tuple field to force use of constructor.
@@ -293,39 +293,39 @@ impl SystemTimeSource {
 }
 
 impl TimeSource for SystemTimeSource {
-    fn utc_now(&self) -> DateTime<Utc> {
-        Utc::now()
+    fn now_utc(&self) -> OffsetDateTime {
+        OffsetDateTime::now_utc()
     }
 }
 
 /// A time source to use for testing, allows the current time to be
 /// set manually.
 pub struct MockTimeSource {
-    time: RwLock<DateTime<Utc>>,
+    time: RwLock<OffsetDateTime>,
 }
 
 impl MockTimeSource {
-    pub fn new(time: DateTime<Utc>) -> Self {
+    pub fn new(time: OffsetDateTime) -> Self {
         Self {
             time: RwLock::new(time),
         }
     }
 
-    pub fn set_time(&self, time: DateTime<Utc>) {
+    pub fn set_time(&self, time: OffsetDateTime) {
         *self.time.write().expect("Unable to lock to write time") = time;
     }
 
-    pub fn time(&self) -> DateTime<Utc> {
+    pub fn time(&self) -> OffsetDateTime {
         *self.time.read().expect("Unable to obtain lock to read time")
     }
 
-    pub fn update<F: Fn(DateTime<Utc>) -> DateTime<Utc>>(&self, f: F) {
+    pub fn update<F: Fn(OffsetDateTime) -> OffsetDateTime>(&self, f: F) {
         self.set_time(f(self.time()))
     }
 }
 
 impl TimeSource for MockTimeSource {
-    fn utc_now(&self) -> DateTime<Utc> {
+    fn now_utc(&self) -> OffsetDateTime {
         *self.time.read().expect("Unable to obtain lock to read time")
     }
 }
@@ -415,7 +415,7 @@ impl Coordinator {
             // Check if the ceremony has been initialized yet.
             if Self::load_current_round_height(&self.storage).is_err() {
                 info!("Initializing ceremony");
-                let round_height = self.run_initialization(self.time.utc_now())?;
+                let round_height = self.run_initialization(self.time.now_utc())?;
                 info!("Initialized ceremony");
 
                 // Initialize the coordinator state to round 0.
@@ -529,7 +529,7 @@ impl Coordinator {
             // Backup a copy of the current coordinator.
 
             // Fetch the current time.
-            let started_at = self.time.utc_now();
+            let started_at = self.time.now_utc();
 
             // Attempt to advance to the next round.
             let next_round_height = self.try_advance(started_at)?;
@@ -579,7 +579,7 @@ impl Coordinator {
     /// Returns a list of the contributors currently in the queue.
     ///
     #[inline]
-    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>))> {
+    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime))> {
         self.state.queue_contributors()
     }
 
@@ -1272,7 +1272,7 @@ impl Coordinator {
     /// Attempts to advance the ceremony to the next round.
     ///
     #[tracing::instrument(skip(self, started_at))]
-    pub fn try_advance(&mut self, started_at: DateTime<Utc>) -> Result<u64, CoordinatorError> {
+    pub fn try_advance(&mut self, started_at: OffsetDateTime) -> Result<u64, CoordinatorError> {
         tracing::debug!("Trying to advance to the next round.");
 
         // Check that the current round height matches in storage and self.
@@ -1948,7 +1948,7 @@ impl Coordinator {
     #[inline]
     pub(crate) fn next_round(
         &mut self,
-        started_at: DateTime<Utc>,
+        started_at: OffsetDateTime,
         contributors: Vec<Participant>,
     ) -> Result<u64, CoordinatorError> {
         // Check that the next round has at least one authorized contributor.
@@ -2041,7 +2041,7 @@ impl Coordinator {
     /// and run `Initialization` to start the ceremony.
     ///
     #[inline]
-    pub(super) fn run_initialization(&mut self, started_at: DateTime<Utc>) -> Result<u64, CoordinatorError> {
+    pub(super) fn run_initialization(&mut self, started_at: OffsetDateTime) -> Result<u64, CoordinatorError> {
         // Check that the ceremony has not begun yet.
         if Self::load_current_round_height(&self.storage).is_ok() {
             return Err(CoordinatorError::RoundAlreadyInitialized);
@@ -2122,7 +2122,7 @@ impl Coordinator {
         }
 
         // Set the finished time for round 0.
-        round.try_finish(self.time.utc_now());
+        round.try_finish(self.time.now_utc());
 
         // Add the new round to storage.
         self.storage
@@ -2653,7 +2653,6 @@ mod tests {
         Coordinator,
     };
 
-    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
     use std::{
@@ -2661,6 +2660,7 @@ mod tests {
         net::{IpAddr, Ipv4Addr},
         sync::Arc,
     };
+    use time::OffsetDateTime;
 
     fn initialize_to_round_1(
         coordinator: &mut Coordinator,
@@ -2753,7 +2753,7 @@ mod tests {
 
         // Check that round 0 matches the round 0 JSON specification.
         {
-            let now = Utc::now();
+            let now = OffsetDateTime::now_utc();
 
             // Fetch round 0 from coordinator.
             let mut expected = test_round_0_json()?;
@@ -3392,7 +3392,7 @@ mod tests {
             coordinator.aggregate_contributions()?;
 
             // Run aggregation and transition from round 1 to round 2.
-            coordinator.next_round(Utc::now(), vec![contributor.clone()])?;
+            coordinator.next_round(OffsetDateTime::now_utc(), vec![contributor.clone()])?;
         }
 
         // Check that the ceremony has advanced to round 2.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use phase1::ProvingSystem;
 
-use chrono::{DateTime, Duration, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -18,6 +17,7 @@ use std::{
     iter::FromIterator,
     net::IpAddr,
 };
+use time::{Duration, OffsetDateTime};
 use tracing::*;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,7 +37,7 @@ pub struct ChunkLock {
     /// The id of the chunk which is locked.
     chunk_id: u64,
     /// The time that the chunk was locked.
-    lock_time: DateTime<Utc>,
+    lock_time: OffsetDateTime,
 }
 
 impl ChunkLock {
@@ -46,7 +46,7 @@ impl ChunkLock {
     pub fn new(chunk_id: u64, time: &dyn TimeSource) -> Self {
         Self {
             chunk_id,
-            lock_time: time.utc_now(),
+            lock_time: time.now_utc(),
         }
     }
 
@@ -56,7 +56,7 @@ impl ChunkLock {
     }
 
     /// The time that the chunk was locked.
-    pub fn lock_time(&self) -> &DateTime<Utc> {
+    pub fn lock_time(&self) -> &OffsetDateTime {
         &self.lock_time
     }
 }
@@ -72,15 +72,15 @@ pub struct ParticipantInfo {
     /// The bucket ID that this participant starts contributing from.
     bucket_id: u64,
     /// The timestamp of the first seen instance of this participant.
-    first_seen: DateTime<Utc>,
+    first_seen: OffsetDateTime,
     /// The timestamp of the last seen instance of this participant.
-    last_seen: DateTime<Utc>,
+    last_seen: OffsetDateTime,
     /// The timestamp when this participant started the round.
-    started_at: Option<DateTime<Utc>>,
+    started_at: Option<OffsetDateTime>,
     /// The timestamp when this participant finished the round.
-    finished_at: Option<DateTime<Utc>>,
+    finished_at: Option<OffsetDateTime>,
     /// The timestamp when this participant was dropped from the round.
-    dropped_at: Option<DateTime<Utc>>,
+    dropped_at: Option<OffsetDateTime>,
     /// A map of chunk IDs to locks on chunks that this participant currently holds.
     locked_chunks: HashMap<u64, ChunkLock>,
     /// The list of (chunk ID, contribution ID) tasks that this participant is assigned to compute.
@@ -111,7 +111,7 @@ impl ParticipantInfo {
         time: &dyn TimeSource,
     ) -> Self {
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
         Self {
             id: participant,
             round_height,
@@ -317,7 +317,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         // Update the last seen time.
         self.last_seen = now;
@@ -380,7 +380,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Add the task to the front of the pending tasks.
         self.assigned_tasks.push_front(task);
@@ -417,7 +417,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Fetch the next task in order as stored.
         match self.assigned_tasks.pop_front() {
@@ -483,7 +483,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         let chunk_lock = ChunkLock::new(chunk_id, time);
 
@@ -544,7 +544,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&task.chunk_id());
@@ -623,7 +623,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Remove the task from the pending tasks.
         self.pending_tasks = self
@@ -699,7 +699,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&task.chunk_id());
@@ -767,7 +767,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.utc_now();
+        self.last_seen = time.now_utc();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&chunk_id);
@@ -804,7 +804,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         // Set the participant info to reflect them dropping now.
         self.dropped_at = Some(now);
@@ -860,7 +860,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         // Update the last seen time.
         self.last_seen = now;
@@ -900,9 +900,9 @@ pub struct RoundMetrics {
     /// The average seconds per task calculated from all current verifiers.
     verifier_average_per_task: Option<u64>,
     /// The timestamp when the coordinator started aggregation of the current round.
-    started_aggregation_at: Option<DateTime<Utc>>,
+    started_aggregation_at: Option<OffsetDateTime>,
     /// The timestamp when the coordinator finished aggregation of the current round.
-    finished_aggregation_at: Option<DateTime<Utc>>,
+    finished_aggregation_at: Option<OffsetDateTime>,
     /// The estimated number of seconds remaining for the current round to finish.
     estimated_finish_time: Option<u64>,
     /// The estimated number of seconds remaining for the current round to aggregate.
@@ -910,7 +910,7 @@ pub struct RoundMetrics {
     /// The estimated number of seconds remaining until the queue is closed for the next round.
     estimated_wait_time: Option<u64>,
     /// The timestamp of the earliest start time for the next round.
-    next_round_after: Option<DateTime<Utc>>,
+    next_round_after: Option<OffsetDateTime>,
 }
 
 impl Default for RoundMetrics {
@@ -941,7 +941,7 @@ pub struct CoordinatorState {
     status: CoordinatorStatus,
     /// The map of queue participants with a reliability score, an assigned future
     /// round, a last seen timestamp, and their time of joining.
-    queue: HashMap<Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>)>,
+    queue: HashMap<Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime)>,
     /// The map of unique participants for the next round.
     next: HashMap<Participant, ParticipantInfo>,
     /// The metrics for the current round of the ceremony.
@@ -1072,8 +1072,8 @@ impl CoordinatorState {
 
             let current_metrics = Some(RoundMetrics {
                 is_round_aggregated: true,
-                started_aggregation_at: Some(time.utc_now()),
-                finished_aggregation_at: Some(time.utc_now()),
+                started_aggregation_at: Some(time.now_utc()),
+                finished_aggregation_at: Some(time.now_utc()),
                 ..Default::default()
             });
 
@@ -1086,8 +1086,8 @@ impl CoordinatorState {
                     (
                         participant_info.reliability,
                         Some(participant_info.round_height),
-                        time.utc_now(),
-                        time.utc_now(),
+                        time.now_utc(),
+                        time.now_utc(),
                     ),
                 );
             }
@@ -1294,7 +1294,7 @@ impl CoordinatorState {
     pub fn queue_contributor_info(
         &self,
         participant: &Participant,
-    ) -> Option<&(u8, Option<u64>, DateTime<Utc>, DateTime<Utc>)> {
+    ) -> Option<&(u8, Option<u64>, OffsetDateTime, OffsetDateTime)> {
         self.queue.get(participant)
     }
 
@@ -1302,7 +1302,7 @@ impl CoordinatorState {
     /// Returns a list of the contributors currently in the queue.
     ///
     #[inline]
-    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>))> {
+    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime))> {
         self.queue
             .clone()
             .into_par_iter()
@@ -1440,7 +1440,7 @@ impl CoordinatorState {
         // Check that the time to trigger the next round has been reached.
         if let Some(metrics) = &self.current_metrics {
             if let Some(next_round_after) = metrics.next_round_after {
-                if time.utc_now() < next_round_after {
+                if time.now_utc() < next_round_after {
                     trace!("Required queue wait time has not been reached yet");
                     return false;
                 }
@@ -1544,7 +1544,7 @@ impl CoordinatorState {
 
         // Add the participant to the queue.
         self.queue
-            .insert(participant, (reliability_score, None, time.utc_now(), time.utc_now()));
+            .insert(participant, (reliability_score, None, time.now_utc(), time.now_utc()));
 
         Ok(())
     }
@@ -1922,7 +1922,7 @@ impl CoordinatorState {
             };
 
             // Add the given task with a new start timer.
-            updated_tasks.insert(*task, (time.utc_now().timestamp(), None));
+            updated_tasks.insert(*task, (time.now_utc().unix_timestamp(), None));
 
             // Set the current task timer for the given participant to the updated task timer.
             metrics.task_timer.insert(participant.clone(), updated_tasks);
@@ -1954,7 +1954,7 @@ impl CoordinatorState {
             match updated_tasks.get_mut(task) {
                 Some((_, end)) => {
                     if end.is_none() {
-                        *end = Some(time.utc_now().timestamp());
+                        *end = Some(time.now_utc().unix_timestamp());
                     }
                 }
                 None => {
@@ -1992,7 +1992,7 @@ impl CoordinatorState {
         }
 
         // Set the start aggregation timestamp to now.
-        metrics.started_aggregation_at = Some(time.utc_now());
+        metrics.started_aggregation_at = Some(time.now_utc());
 
         Ok(())
     }
@@ -2024,7 +2024,7 @@ impl CoordinatorState {
         metrics.is_round_aggregated = true;
 
         // Set the finish aggregation timestamp to now.
-        metrics.finished_aggregation_at = Some(time.utc_now());
+        metrics.finished_aggregation_at = Some(time.now_utc());
 
         // Update the time to trigger the next round.
         if metrics.next_round_after.is_none() {
@@ -2039,7 +2039,7 @@ impl CoordinatorState {
     fn update_next_round_after(&mut self, time: &dyn TimeSource) {
         if let Some(metrics) = &mut self.current_metrics {
             metrics.next_round_after =
-                Some(time.utc_now() + Duration::seconds(self.environment.queue_wait_time() as i64));
+                Some(time.now_utc() + Duration::seconds(self.environment.queue_wait_time() as i64));
         }
     }
 
@@ -2593,7 +2593,7 @@ impl CoordinatorState {
     pub(super) fn update_dropped_queued_participants(&mut self, time: &dyn TimeSource) -> Result<(), CoordinatorError> {
         let queue_seen_timeout = self.environment.queue_seen_timeout();
 
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         for (participant, (_, _, last_seen, _)) in self.queue.clone() {
             if now - last_seen > queue_seen_timeout {
@@ -2616,7 +2616,7 @@ impl CoordinatorState {
         let participant_lock_timeout = self.environment.participant_lock_timeout();
 
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         self.current_contributors
             .clone()
@@ -2637,10 +2637,10 @@ impl CoordinatorState {
                     let exceeded_chunks_string: String = exceeded_chunk_names.join(", ");
 
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({}) allowed time \
+                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
                         it is allowed to hold a lock (on chunks {}).",
                         participant,
-                        chrono_humanize::HumanTime::from(participant_lock_timeout),
+                        participant_lock_timeout.whole_seconds(),
                         exceeded_chunks_string,
                     );
                     Some(self.drop_participant(participant, time))
@@ -2662,7 +2662,7 @@ impl CoordinatorState {
         let contributor_seen_timeout = self.environment.contributor_seen_timeout();
 
         // Fetch the current time.
-        let now = time.utc_now();
+        let now = time.now_utc();
 
         self.current_contributors
             .clone()
@@ -2674,11 +2674,11 @@ impl CoordinatorState {
                 // Check if the participant is still live and not a coordinator contributor.
                 if elapsed > contributor_seen_timeout && !self.is_coordinator_contributor(&participant) {
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({}) allowed time \
-                        since it was last seen by the coordinator (last seen {} ago).",
+                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
+                        since it was last seen by the coordinator (last seen {:?}s ago).",
                         participant,
-                        chrono_humanize::HumanTime::from(contributor_seen_timeout),
-                        chrono_humanize::HumanTime::from(elapsed)
+                        contributor_seen_timeout.whole_seconds(),
+                        elapsed.whole_seconds()
                     );
                     // Drop the participant.
                     Some(self.drop_participant(participant, time))
@@ -2889,7 +2889,7 @@ impl CoordinatorState {
         // Check that the time to trigger the next round has been reached, if it is set.
         if let Some(metrics) = &self.current_metrics {
             if let Some(next_round_after) = metrics.next_round_after {
-                if time.utc_now() < next_round_after {
+                if time.now_utc() < next_round_after {
                     return Err(CoordinatorError::QueueWaitTimeIncomplete);
                 }
             }
@@ -3116,8 +3116,8 @@ impl CoordinatorState {
                 (
                     participant_info.reliability,
                     Some(participant_info.round_height),
-                    time.utc_now(),
-                    time.utc_now(),
+                    time.now_utc(),
+                    time.now_utc(),
                 ),
             );
         }
@@ -3214,7 +3214,7 @@ impl CoordinatorState {
         time: &dyn TimeSource,
     ) -> Result<(), CoordinatorError> {
         if let Some((_, _, last_seen, _)) = self.queue.get_mut(participant) {
-            *last_seen = time.utc_now();
+            *last_seen = time.now_utc();
             return Ok(());
         }
 
@@ -3240,7 +3240,7 @@ impl CoordinatorState {
         };
 
         if let Some(info) = info {
-            info.last_seen = time.utc_now();
+            info.last_seen = time.now_utc();
             Ok(())
         } else {
             Err(CoordinatorError::ParticipantNotFound(participant.clone()))
@@ -4372,7 +4372,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(Utc::now());
+        let time = MockTimeSource::new(OffsetDateTime::now_utc());
 
         let action = state.reset_current_round(false, &time).unwrap();
         assert!(!action.rollback);
@@ -4532,7 +4532,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(Utc::now());
+        let time = MockTimeSource::new(OffsetDateTime::now_utc());
 
         dbg!(&state.current_contributors());
 
@@ -4655,7 +4655,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(Utc::now());
+        let time = MockTimeSource::new(OffsetDateTime::now_utc());
 
         let drop = state.drop_participant(&contributor_1, &time).unwrap();
 

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -260,6 +260,8 @@ pub struct Environment {
     deployment: Deployment,
     /// The base directory for disk storage of this coordinator.
     local_base_directory: String,
+
+    disable_reliability_zeroing: bool,
 }
 
 impl Environment {
@@ -453,6 +455,10 @@ impl Environment {
     pub(crate) fn storage(&self) -> anyhow::Result<Disk> {
         Ok(Disk::load(self)?)
     }
+
+    pub(crate) fn disable_reliability_zeroing(&self) -> bool {
+        self.disable_reliability_zeroing
+    }
 }
 
 impl From<Testing> for Environment {
@@ -487,6 +493,11 @@ impl Testing {
 
     pub fn maximum_contributors_per_round(mut self, maximum: usize) -> Self {
         self.environment.maximum_contributors_per_round = maximum;
+        self
+    }
+
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
         self
     }
 
@@ -579,6 +590,8 @@ impl std::default::Default for Testing {
                 software_version: 1,
                 deployment: Deployment::Testing,
                 local_base_directory: "./transcript/testing".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }
@@ -608,6 +621,11 @@ impl Development {
 
     pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
+        self
+    }
+
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
         self
     }
 
@@ -688,6 +706,8 @@ impl std::default::Default for Development {
                 software_version: 1,
                 deployment: Deployment::Development,
                 local_base_directory: "./transcript/development".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }
@@ -722,6 +742,11 @@ impl Production {
 
     pub fn queue_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.queue_seen_timeout = timeout;
+        self
+    }
+
+    pub fn disable_reliability_zeroing(mut self, disable_zeroing: bool) -> Self {
+        self.environment.disable_reliability_zeroing = disable_zeroing;
         self
     }
 
@@ -796,6 +821,8 @@ impl std::default::Default for Production {
                 software_version: 1,
                 deployment: Deployment::Production,
                 local_base_directory: "./transcript".to_string(),
+
+                disable_reliability_zeroing: false,
             },
         }
     }

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -4,7 +4,6 @@ use setup_utils::{CheckForCorrectness, UseCompression};
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use serde_with::DurationSecondsWithFrac;
 
 type BatchSize = usize;
 type ChunkSize = usize;
@@ -225,21 +224,17 @@ pub struct Environment {
     /// Returns the maximum duration a contributor can go without
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    contributor_seen_timeout: chrono::Duration,
+    contributor_seen_timeout: time::Duration,
     /// The maximum duration a verifier can go without being seen by
     /// the coordinator before it will be dropped from the ceremony by
     /// the coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    verifier_seen_timeout: chrono::Duration,
+    verifier_seen_timeout: time::Duration,
     /// The maximum duration a lock can be held by a participant
     /// before it will be dropped from the ceremony by the
     /// coordinator.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    participant_lock_timeout: chrono::Duration,
+    participant_lock_timeout: time::Duration,
     /// The maximum duration a queued contributor can go without a heartbeat.
-    #[serde_as(as = "DurationSecondsWithFrac<String>")]
-    queue_seen_timeout: chrono::Duration,
+    queue_seen_timeout: time::Duration,
     /// The number of drops tolerated by a participant before banning them from future rounds.
     participant_ban_threshold: u16,
     /// The setting to allow current contributors to join the queue for the next round.
@@ -339,7 +334,7 @@ impl Environment {
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
     ///
-    pub const fn contributor_seen_timeout(&self) -> chrono::Duration {
+    pub const fn contributor_seen_timeout(&self) -> time::Duration {
         self.contributor_seen_timeout
     }
 
@@ -348,7 +343,7 @@ impl Environment {
     /// seen by the coordinator before it will be dropped from the
     /// ceremony by the coordinator.
     ///
-    pub const fn verifier_seen_timeout(&self) -> chrono::Duration {
+    pub const fn verifier_seen_timeout(&self) -> time::Duration {
         self.verifier_seen_timeout
     }
 
@@ -357,7 +352,7 @@ impl Environment {
     /// lock before being dropped from the ceremony by the
     /// coordinator.
     ///
-    pub const fn participant_lock_timeout(&self) -> chrono::Duration {
+    pub const fn participant_lock_timeout(&self) -> time::Duration {
         self.participant_lock_timeout
     }
 
@@ -365,7 +360,7 @@ impl Environment {
     /// Returns the maximum duration that a queued contributor can go
     /// without a heartbeat.
     ///
-    pub const fn queue_seen_timeout(&self) -> chrono::Duration {
+    pub const fn queue_seen_timeout(&self) -> time::Duration {
         self.queue_seen_timeout
     }
 
@@ -525,19 +520,19 @@ impl Testing {
         deployment
     }
 
-    pub fn contributor_seen_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(&self, contributor_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.contributor_seen_timeout = contributor_timeout;
         deployment
     }
 
-    pub fn participant_lock_timeout(&self, participant_lock_timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(&self, participant_lock_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.participant_lock_timeout = participant_lock_timeout;
         deployment
     }
 
-    pub fn queue_seen_timeout(&self, queue_seen_timeout: chrono::Duration) -> Self {
+    pub fn queue_seen_timeout(&self, queue_seen_timeout: time::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.queue_seen_timeout = queue_seen_timeout;
         deployment
@@ -575,10 +570,10 @@ impl std::default::Default for Testing {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::minutes(5),
-                verifier_seen_timeout: chrono::Duration::minutes(15),
-                participant_lock_timeout: chrono::Duration::minutes(20),
-                queue_seen_timeout: chrono::Duration::days(10),
+                contributor_seen_timeout: time::Duration::minutes(5),
+                verifier_seen_timeout: time::Duration::minutes(15),
+                participant_lock_timeout: time::Duration::minutes(20),
+                queue_seen_timeout: time::Duration::days(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -614,12 +609,12 @@ impl Development {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
@@ -691,10 +686,10 @@ impl std::default::Default for Development {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::minutes(1),
-                verifier_seen_timeout: chrono::Duration::minutes(15),
-                participant_lock_timeout: chrono::Duration::minutes(20),
-                queue_seen_timeout: chrono::Duration::minutes(10),
+                contributor_seen_timeout: time::Duration::minutes(1),
+                verifier_seen_timeout: time::Duration::minutes(15),
+                participant_lock_timeout: time::Duration::minutes(20),
+                queue_seen_timeout: time::Duration::minutes(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -730,17 +725,17 @@ impl Production {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
 
-    pub fn queue_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
+    pub fn queue_seen_timeout(mut self, timeout: time::Duration) -> Self {
         self.environment.queue_seen_timeout = timeout;
         self
     }
@@ -806,10 +801,10 @@ impl std::default::Default for Production {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: chrono::Duration::days(7),
-                verifier_seen_timeout: chrono::Duration::days(7),
-                participant_lock_timeout: chrono::Duration::days(7),
-                queue_seen_timeout: chrono::Duration::days(7),
+                contributor_seen_timeout: time::Duration::days(7),
+                verifier_seen_timeout: time::Duration::days(7),
+                participant_lock_timeout: time::Duration::days(7),
+                queue_seen_timeout: time::Duration::days(7),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: false,
                 allow_current_verifiers_in_queue: true,

--- a/phase1-coordinator/src/objects/round.rs
+++ b/phase1-coordinator/src/objects/round.rs
@@ -15,12 +15,12 @@ use crate::{
     CoordinatorError,
 };
 
-use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::*;
 use serde_diff::SerdeDiff;
 use std::{collections::HashSet, hash::Hash};
+use time::OffsetDateTime;
 use tracing::{debug, error, trace, warn};
 
 use super::Task;
@@ -74,9 +74,11 @@ pub struct Round {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     height: u64,
     #[serde_diff(opaque)]
-    started_at: Option<DateTime<Utc>>,
+    #[serde(with = "time::serde::timestamp::option")]
+    started_at: Option<OffsetDateTime>,
     #[serde_diff(opaque)]
-    finished_at: Option<DateTime<Utc>>,
+    #[serde(with = "time::serde::timestamp::option")]
+    finished_at: Option<OffsetDateTime>,
     contributor_ids: Vec<Participant>,
     verifier_ids: Vec<Participant>,
     chunks: Vec<Chunk>,
@@ -89,7 +91,7 @@ impl Round {
         environment: &Environment,
         storage: &mut Disk,
         round_height: u64,
-        started_at: DateTime<Utc>,
+        started_at: OffsetDateTime,
         contributor_ids: Vec<Participant>,
     ) -> Result<Self, CoordinatorError> {
         debug!("Starting to create round {}", round_height);
@@ -758,7 +760,7 @@ impl Round {
 
         // If all chunks are complete and the finished at timestamp has not been set yet,
         // then set it with the current UTC timestamp.
-        self.try_finish(Utc::now());
+        self.try_finish(OffsetDateTime::now_utc());
 
         Ok(())
     }
@@ -1094,7 +1096,7 @@ impl Round {
     /// then set it with the current UTC timestamp.
     ///
     #[inline]
-    pub(crate) fn try_finish(&mut self, timestamp: DateTime<Utc>) {
+    pub(crate) fn try_finish(&mut self, timestamp: OffsetDateTime) {
         if self.is_complete() && self.finished_at.is_none() {
             self.finished_at = Some(timestamp);
         }
@@ -1105,7 +1107,7 @@ impl Round {
     ///
     #[cfg(test)]
     #[inline]
-    pub(crate) fn try_finish_testing_only_unsafe(&mut self, timestamp: DateTime<Utc>) {
+    pub(crate) fn try_finish_testing_only_unsafe(&mut self, timestamp: OffsetDateTime) {
         if self.is_complete() {
             warn!("Modifying finished_at timestamp for testing only");
             self.finished_at = Some(timestamp);

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -7,12 +7,12 @@ use crate::{
     CoordinatorError,
 };
 
-use chrono::{DateTime, TimeZone, Utc};
 use once_cell::sync::Lazy;
 use serde_diff::{Diff, SerdeDiff};
 #[cfg(test)]
 use serial_test::serial;
 use std::{path::Path, sync::Arc};
+use time::{macros::datetime, OffsetDateTime};
 use tracing::*;
 
 use fs_err as fs;
@@ -27,7 +27,7 @@ pub static TEST_ENVIRONMENT: Lazy<Environment> = Lazy::new(|| Testing::from(Para
 pub static TEST_ENVIRONMENT_3: Lazy<Environment> = Lazy::new(|| Testing::from(Parameters::Test3Chunks).into());
 
 /// Round start datetime for testing purposes only.
-pub static TEST_STARTED_AT: Lazy<DateTime<Utc>> = Lazy::new(|| Utc.ymd(1970, 1, 1).and_hms(0, 1, 1));
+pub static TEST_STARTED_AT: Lazy<OffsetDateTime> = Lazy::new(|| datetime!(1970-01-01 00:01:01 UTC));
 
 /// Contributor ID for testing purposes only.
 pub static TEST_CONTRIBUTOR_ID: Lazy<Participant> =

--- a/phase1-coordinator/src/testing/resources/round.json
+++ b/phase1-coordinator/src/testing/resources/round.json
@@ -1,7 +1,7 @@
 {
     "version": 0,
     "height": 0,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [
         "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",

--- a/phase1-coordinator/src/testing/resources/test_round_0.json
+++ b/phase1-coordinator/src/testing/resources/test_round_0.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 0,
     "timestamp": null,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [],
     "verifierIds": [],

--- a/phase1-coordinator/src/testing/resources/test_round_1_initial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_initial.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 1,
     "timestamp": null,
-    "startedAt": "1970-01-01T00:01:01Z",
+    "startedAt": 61,
     "finishedAt": null,
     "contributorIds": [
         "testing-coordinator-contributor.contributor"

--- a/phase1-coordinator/src/testing/resources/test_round_1_partial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_partial.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "height": 1,
-  "startedAt": "2021-06-22T17:25:21.109306563Z",
+  "startedAt": 1624382721,
   "finishedAt": null,
   "contributorIds": [
     "testing-coordinator-contributor-3.contributor",

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -20,6 +20,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
     collections::{HashSet, LinkedList},
     iter::FromIterator,
+    net::{IpAddr, Ipv4Addr},
     sync::Arc,
 };
 
@@ -110,8 +111,9 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
 
     // Meanwhile, add a contributor and verifier to the queue.
     let (contributor, contributor_signing_key, seed) = create_contributor("1");
+    let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor.clone(), 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -135,7 +137,7 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     // changing the outcome of this test, if necessary.
     //
     let (contributor, _, _) = create_contributor("1");
-    coordinator.add_to_queue(contributor.clone(), 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Update the ceremony from round 1 to round 2.
@@ -229,10 +231,16 @@ fn coordinator_drop_contributor_basic() {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor2.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
+        .unwrap();
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -337,12 +345,15 @@ fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -457,12 +468,15 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -610,12 +624,15 @@ fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -769,10 +786,12 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -882,12 +901,21 @@ fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor2.clone(), 9).unwrap();
-    coordinator.add_to_queue(contributor3.clone(), 8).unwrap();
+    coordinator
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)
+        .unwrap();
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1079,10 +1107,12 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1162,10 +1192,16 @@ fn coordinator_drop_contributor_and_release_locks() {
 
     // Add a contributor and verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1186,12 +1222,14 @@ fn coordinator_drop_contributor_and_release_locks() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1233,12 +1271,21 @@ fn coordinator_drop_several_contributors() {
 
     // Add some contributors and one verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_3.participant.clone(), 10).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_3.participant.clone(), Some(contributor_3_ip), 10)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1309,12 +1356,14 @@ fn coordinator_drop_several_contributors() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1438,10 +1487,16 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
 
     // Add a contributor and verifier to the queue.
     let contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
-    coordinator.add_to_queue(contributor_1.participant.clone(), 10).unwrap();
-    coordinator.add_to_queue(contributor_2.participant.clone(), 9).unwrap();
+    coordinator
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .unwrap();
+    coordinator
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
+        .unwrap();
 
     // Update the ceremony to round 1.
     coordinator.update().unwrap();
@@ -1462,12 +1517,14 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1506,12 +1563,15 @@ fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1653,10 +1713,12 @@ fn try_lock_blocked() -> anyhow::Result<()> {
 
     // Meanwhile, add 2 contributors and 1 verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -1777,10 +1839,12 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let test_contributor_1 = create_contributor_test_details("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let test_contributor_2 = create_contributor_test_details("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(test_contributor_1.participant.clone(), 10)?;
-    coordinator.add_to_queue(test_contributor_2.participant.clone(), 9)?;
+    coordinator.add_to_queue(test_contributor_1.participant.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(test_contributor_2.participant.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1818,9 +1882,11 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
 
     // Add some more participants to proceed to the next round
     let test_contributor_3 = create_contributor_test_details("3");
+    let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
-    coordinator.add_to_queue(test_contributor_3.participant.clone(), 10)?;
-    coordinator.add_to_queue(test_contributor_4.participant.clone(), 10)?;
+    let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
+    coordinator.add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)?;
+    coordinator.add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)?;
 
     // Update the ceremony to round 2.
     coordinator.update()?;
@@ -1853,10 +1919,12 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
 
     // Add a contributor and verifier to the queue.
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1931,8 +1999,9 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _contributor_signing_key1, _seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1991,10 +2060,12 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2064,8 +2135,9 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2129,15 +2201,17 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _, _) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
 
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2193,15 +2267,18 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _, _) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
 
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
-    coordinator.add_to_queue(contributor2.clone(), 10)?;
+    let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
+
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2262,8 +2339,9 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
+    let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -11,8 +11,8 @@ use crate::{
     Participant,
     Round,
 };
-use chrono::Utc;
 use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
+use time::OffsetDateTime;
 
 use fs_err as fs;
 use rand::RngCore;
@@ -1975,7 +1975,7 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -1987,8 +1987,8 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(5))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(5))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2011,14 +2011,14 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // contributor to timeout)
-    time.update(|prev| prev + chrono::Duration::minutes(1));
+    time.update(|prev| prev + time::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::minutes(5));
+    time.update(|prev| prev + time::Duration::minutes(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2036,7 +2036,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_wait_verifier_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2047,8 +2047,8 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
         16, /* chunk_size */
     ));
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(5))
-        .participant_lock_timeout(chrono::Duration::minutes(8));
+        .contributor_seen_timeout(time::Duration::minutes(5))
+        .participant_lock_timeout(time::Duration::minutes(8));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
     let number_of_chunks = environment.number_of_chunks() as usize;
@@ -2071,7 +2071,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     coordinator.update()?;
 
     for _ in 0..(number_of_chunks / 2) {
-        time.update(|prev| prev + chrono::Duration::minutes(1));
+        time.update(|prev| prev + time::Duration::minutes(1));
         coordinator.contribute(&contributor1, &contributor_signing_key1, &seed1)?;
         coordinator.contribute(&contributor2, &contributor_signing_key2, &seed2)?;
     }
@@ -2085,7 +2085,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 
     // contributors are stuck waiting for 10 minutes, longer than the
     // contributor timeout duration.
-    time.update(|prev| prev + chrono::Duration::minutes(10));
+    time.update(|prev| prev + time::Duration::minutes(10));
 
     // Emulate contributor querying the current round via the
     // `/v1/round/current` endpoint.
@@ -2111,7 +2111,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2123,8 +2123,8 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(20))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(20))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2151,14 +2151,14 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::minutes(1));
+    time.update(|prev| prev + time::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::minutes(10));
+    time.update(|prev| prev + time::Duration::minutes(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2177,7 +2177,7 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2189,8 +2189,8 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::days(20))
-        .participant_lock_timeout(chrono::Duration::days(20));
+        .contributor_seen_timeout(time::Duration::days(20))
+        .participant_lock_timeout(time::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2219,7 +2219,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
@@ -2227,7 +2227,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::days(10));
+    time.update(|prev| prev + time::Duration::days(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2243,7 +2243,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2255,8 +2255,8 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::days(20))
-        .participant_lock_timeout(chrono::Duration::days(20));
+        .contributor_seen_timeout(time::Duration::days(20))
+        .participant_lock_timeout(time::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2286,7 +2286,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     // Send heartbeat from contributor2
@@ -2297,7 +2297,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + chrono::Duration::days(5));
+    time.update(|prev| prev + time::Duration::days(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2315,7 +2315,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn rollback_locked_chunk() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(Utc::now()));
+    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2327,8 +2327,8 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(chrono::Duration::minutes(20))
-        .participant_lock_timeout(chrono::Duration::minutes(10));
+        .contributor_seen_timeout(time::Duration::minutes(20))
+        .participant_lock_timeout(time::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 

--- a/phase1-wasm-keys/Cargo.toml
+++ b/phase1-wasm-keys/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "phase1-wasm-keys"
+version = "0.1.0"
+authors = ["The Aleo Team <hello@aleo.org>"]
+description = "WASM binary to generate Setup keys"
+homepage = "https://github.com/AleoHQ/aleo-setup"
+repository = "https://github.com/AleoHQ/aleo-setup"
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM.git", branch = "setup_wasm", default-features = false, features = [ "wasm" ] }
+rand = { version = "0.8" }
+wasm-bindgen = { version = "0.2.69", features=["serde-serialize"] }
+getrandom = { version = "0.2", features = ["js", "wasm-bindgen"] }
+blake2 = { version = "0.9", default-features = false } 
+hex = { version = "0.4" }

--- a/phase1-wasm-keys/LICENSE-APACHE
+++ b/phase1-wasm-keys/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/phase1-wasm-keys/LICENSE-MIT
+++ b/phase1-wasm-keys/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/phase1-wasm-keys/src/lib.rs
+++ b/phase1-wasm-keys/src/lib.rs
@@ -1,0 +1,32 @@
+use blake2::{Blake2s, Digest};
+use rand::{CryptoRng, Rng};
+use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, Address, PrivateKey};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn generate_keys() -> Result<JsValue, JsValue> {
+    let mut rng = rand::thread_rng();
+    let private_key = PrivateKey::new(&mut rng);
+    let address = Address::from_private_key(&private_key).expect("Should have derived an Aleo address");
+    let (confirmation_key, new_private_key) = generate_confirmation_key(&address, &mut rng);
+
+    Ok(JsValue::from_serde(&(
+        address.to_string(),
+        private_key.to_string(),
+        confirmation_key,
+        new_private_key.to_string(),
+    ))
+    .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?)
+}
+
+fn generate_confirmation_key<R: Rng + CryptoRng>(
+    address: &Address<Testnet2Parameters>,
+    rng: &mut R,
+) -> (String, PrivateKey<Testnet2Parameters>) {
+    let new_private_key = PrivateKey::new(rng);
+    let concatenated = format!("{}{}", address.to_string(), new_private_key.to_string());
+    let mut hasher = Blake2s::new();
+    hasher.update(concatenated.as_bytes());
+    let bytes = hasher.finalize().to_vec();
+    (hex::encode(&bytes), new_private_key)
+}

--- a/phase1-wasm/Cargo.toml
+++ b/phase1-wasm/Cargo.toml
@@ -12,36 +12,57 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-phase1 = { path = "../phase1" }
-setup-utils = { path = "../setup-utils" }
-snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
-snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
+http = "0.2"
+phase1 = { path = "../phase1", default-features = false }
+setup-utils = { path = "../setup-utils", default-features = false }
+setup1-shared = { path = "../setup1-shared" }
+snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM.git", branch = "setup_wasm", default-features = false, features = [ "wasm" ], optional = true }
+snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM.git", branch = "setup_wasm", default-features = false, optional = true }
+snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false }
+snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c", default-features = false }
 
+blake2 = { version = "0.9", default-features = false }
+bytes = "1.1"
+cfg-if = "1.0"
+hex = { version = "0.4" }
 getrandom = { version = "0.2" }
+oneshot = "0.1"
 rand = { version = "0.8" }
+js-sys = "0.3.45"
 rand_chacha = { version = "0.3" }
+rayon = "1.1.0"
+rayon-core = "1.5.0"
+reqwest = "0.11"
 serde = { version = "1.0.114" }
 serde_derive = { version = "1.0.114" }
+serde_json = "1.0"
+serde-diff = { version = "0.4" }
 tracing = { version = "0.1.21" }
-tracing-subscriber = { version = "0.2.3" }
-wasm-bindgen = { version = "0.2.69", features=["serde-serialize"] }
+tracing-subscriber = { version = "0.3" }
+wasm-bindgen = { version = "0.2.78", features=["serde-serialize"] }
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["console", "ErrorEvent", "Event", "Navigator", "Window", "Worker", "DedicatedWorkerGlobalScope", "MessageEvent", "Response"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.6" }
 
 [dev-dependencies]
 rand_chacha = { version = "0.3" }
 wasm-bindgen-test = { version = "0.3.18" }
 
 [build-dependencies]
-rustc_version = { version = "0.3" }
+rustc_version = { version = "0.4" }
 
 [features]
 default = []
-wasm = ["console_error_panic_hook", "getrandom/js", "getrandom/wasm-bindgen", "phase1/wasm", "setup-utils/wasm"]
+wasm = ["getrandom/js", "getrandom/wasm-bindgen", "phase1/wasm", "setup-utils/wasm", "snarkvm-dpc", "snarkvm-utilities"]
+parallel = ["phase1/parallel", "setup-utils/parallel"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O4']
 
 # cargo test --target wasm32-unknown-unknown --no-default-features --features wasm
 # cargo build --tests --target wasm32-unknown-unknown --no-default-features --features wasm

--- a/phase1-wasm/build.sh
+++ b/phase1-wasm/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -ex
+
+# A couple of steps are necessary to get this build working which makes it slightly
+# nonstandard compared to most other builds.
+#
+# * First, the Rust standard library needs to be recompiled with atomics
+#   enabled. to do that we use Cargo's unstable `-Zbuild-std` feature.
+#
+# * Next we need to compile everything with the `atomics` and `bulk-memory`
+#   features enabled, ensuring that LLVM will generate atomic instructions,
+#   shared memory, passive segments, etc.
+# Note the usage of `--target no-modules` here which is required for passing
+# the memory import to each wasm module.
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals -C codegen-units=1' \
+wasm-pack build --release --target no-modules -- --features wasm --features parallel -Z build-std=std,panic_abort

--- a/phase1-wasm/src/contributor.rs
+++ b/phase1-wasm/src/contributor.rs
@@ -1,0 +1,285 @@
+use crate::{phase1::Phase1WASM, pool::WorkerProcess, requests::*, utils::*};
+use js_sys::{Function, Promise};
+use rand::{CryptoRng, Rng};
+use setup1_shared::structures::LockResponse;
+use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, PrivateKey};
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+// Inner ceremony parameters.
+const CURVE_KIND: &'static str = "bls12_377";
+const PROVING_SYSTEM: &'static str = "groth16";
+const BATCH_SIZE: usize = 2097152;
+const POWER: usize = 19;
+const CHALLENGE_SIZE: usize = 32768;
+
+const DELAY_FIVE_SECONDS: i32 = 5000;
+const DELAY_THIRTY_SECONDS: i32 = 30000;
+const DEFAULT_THREAD_COUNT: usize = 8;
+
+// A custom binding to the JS `setTimeout` function, in order to implement a sleep
+// function.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = setTimeout)]
+    fn set_timeout(f: &Function, time_ms: i32);
+}
+
+/// Performs a full ceremony round, and returns only when all chunks have been
+/// contributed to. Takes in a coordinator URL, an Aleo private key and a
+/// hash of the confirmation key.
+#[wasm_bindgen]
+pub async fn contribute(server_url: String, private_key: String, confirmation_key: String) -> Result<JsValue, JsValue> {
+    let mut rng = rand::thread_rng();
+    let private_key = PrivateKey::from_str(&private_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+    join_queue(&private_key, confirmation_key, server_url.clone(), &mut rng).await?;
+    let worker_pool = WorkerProcess::new(DEFAULT_THREAD_COUNT)?;
+    let seed: [u8; 32] = rng.gen();
+
+    loop {
+        send_heartbeat(&private_key, server_url.clone(), &mut rng).await?;
+
+        let is_finished = attempt_contribution(&private_key, server_url.clone(), &seed, &mut rng, &worker_pool).await?;
+
+        if is_finished {
+            break;
+        }
+    }
+
+    Ok("finished!".into())
+}
+
+async fn attempt_contribution<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    seed: &[u8],
+    rng: &mut R,
+    worker_pool: &WorkerProcess,
+) -> Result<bool, JsValue> {
+    let tasks_left = match get_tasks_left(private_key, server_url.clone(), rng).await {
+        Ok(b) => b,
+        Err(_) => {
+            sleep(DELAY_THIRTY_SECONDS).await?;
+            return Ok(false);
+        }
+    };
+
+    if !tasks_left {
+        return Ok(true);
+    }
+
+    web_sys::console::log_1(&"locking chunk".into());
+    let response = lock_chunk(private_key, server_url.clone(), rng).await?;
+    web_sys::console::log_1(&"chunk locked".into());
+
+    web_sys::console::log_1(&"downloading challenge".into());
+    let chunk_bytes = download_challenge(
+        private_key,
+        server_url.clone(),
+        response.chunk_id,
+        response.contribution_id,
+        rng,
+    )
+    .await?;
+    web_sys::console::log_1(&"challenge downloaded".into());
+    web_sys::console::log_1(&format!("{} bytes", chunk_bytes.len()).into());
+
+    web_sys::console::log_1(&"contributing...".into());
+    let result = Phase1WASM::contribute_chunked(
+        CURVE_KIND,
+        PROVING_SYSTEM,
+        BATCH_SIZE,
+        POWER,
+        response.chunk_id as usize,
+        CHALLENGE_SIZE,
+        seed,
+        chunk_bytes.to_vec(),
+        &worker_pool,
+        DEFAULT_THREAD_COUNT,
+    )
+    .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    web_sys::console::log_1(&"finished!".into());
+
+    web_sys::console::log_1(&"calculating hashes".into());
+    let challenge_hash = calculate_hash(&chunk_bytes);
+    let response_hash = calculate_hash(&result.response);
+
+    web_sys::console::log_1(&"signing contribution".into());
+    let signed_contribution_state = sign_contribution_state(&private_key, &challenge_hash, &response_hash, None, rng)?;
+    let verifier_flag = vec![0];
+    let signature_bytes =
+        hex::decode(signed_contribution_state.get_signature()).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+    let sig_and_result_bytes = [
+        verifier_flag,
+        signature_bytes,
+        challenge_hash,
+        response_hash,
+        result.response,
+    ]
+    .concat();
+
+    web_sys::console::log_1(&"uploading".into());
+    upload_response(
+        private_key,
+        server_url.clone(),
+        response.response_chunk_id,
+        response.response_contribution_id,
+        sig_and_result_bytes.clone(),
+        rng,
+    )
+    .await?;
+
+    web_sys::console::log_1(&"notifying".into());
+    notify_contribution(private_key, server_url.clone(), response.chunk_id, rng).await?;
+
+    Ok(false)
+}
+
+async fn sleep(time_ms: i32) -> Result<(), JsValue> {
+    JsFuture::from(Promise::new(&mut |yes, _| {
+        set_timeout(&yes, time_ms);
+    }))
+    .await?;
+    Ok(())
+}
+
+////////////////////////////////////////////////////////
+/// Fault-tolerant wrappers for coordinator requests ///
+////////////////////////////////////////////////////////
+
+async fn send_heartbeat<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    loop {
+        match post_heartbeat(private_key, server_url.clone(), rng).await {
+            Ok(_) => break,
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_THIRTY_SECONDS).await?;
+            }
+        };
+    }
+
+    Ok(())
+}
+
+async fn join_queue<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    confirmation_key: String,
+    server_url: String,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    loop {
+        match post_join_queue(&private_key, &confirmation_key, server_url.clone(), rng).await {
+            Ok(_) => break,
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_THIRTY_SECONDS).await?;
+            }
+        };
+    }
+
+    Ok(())
+}
+
+async fn lock_chunk<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    rng: &mut R,
+) -> Result<LockResponse, JsValue> {
+    let response;
+
+    loop {
+        match post_lock_chunk(private_key, server_url.clone(), rng).await {
+            Ok(r) => {
+                response = r;
+                break;
+            }
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_FIVE_SECONDS).await?;
+            }
+        };
+    }
+
+    Ok(response)
+}
+
+async fn download_challenge<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    contribution_id: u64,
+    rng: &mut R,
+) -> Result<Vec<u8>, JsValue> {
+    let chunk_bytes;
+
+    loop {
+        match get_challenge(private_key, server_url.clone(), chunk_id, contribution_id, rng).await {
+            Ok(c) => {
+                chunk_bytes = c;
+                break;
+            }
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_FIVE_SECONDS).await?;
+            }
+        }
+    }
+
+    Ok(chunk_bytes)
+}
+
+async fn upload_response<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    contribution_id: u64,
+    sig_and_result_bytes: Vec<u8>,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    loop {
+        match post_response(
+            private_key,
+            server_url.clone(),
+            chunk_id,
+            contribution_id,
+            sig_and_result_bytes.clone(),
+            rng,
+        )
+        .await
+        {
+            Ok(_) => break,
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_FIVE_SECONDS).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn notify_contribution<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    loop {
+        match post_contribution(private_key, server_url.clone(), chunk_id, rng).await {
+            Ok(_) => break,
+            Err(e) => {
+                web_sys::console::log_1(&format!("{:?}", e).into());
+                sleep(DELAY_FIVE_SECONDS).await?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/phase1-wasm/src/errors.rs
+++ b/phase1-wasm/src/errors.rs
@@ -1,0 +1,16 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub enum ContributeError {
+    ChallengeHashSizeInvalid,
+    ResponseHashSizeInvalid,
+    NextChallengeHashSizeInvalid,
+    ContributionSignatureSizeMismatch,
+}
+
+impl From<ContributeError> for JsValue {
+    fn from(value: ContributeError) -> Self {
+        JsValue::from_str(&format!("{:?}", value))
+    }
+}

--- a/phase1-wasm/src/lib.rs
+++ b/phase1-wasm/src/lib.rs
@@ -1,7 +1,22 @@
 #[macro_use]
 extern crate serde_derive;
 
-mod phase1;
+cfg_if::cfg_if! {
+    if #[cfg(not(test))] {
+        #[cfg(feature = "wasm")]
+        mod contributor;
+        #[cfg(feature = "wasm")]
+        mod errors;
+        mod pool;
+        #[cfg(feature = "wasm")]
+        mod requests;
+        #[cfg(feature = "wasm")]
+        mod structures;
+        #[cfg(feature = "wasm")]
+        mod utils;
+    }
+}
 
+mod phase1;
 #[cfg(test)]
 mod tests;

--- a/phase1-wasm/src/pool.rs
+++ b/phase1-wasm/src/pool.rs
@@ -1,0 +1,228 @@
+// Silences warnings from the compiler about Work.func and child_entry_point
+// being unused when the target is not wasm.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
+//! A small module that's intended to provide an example of creating a pool of
+//! web workers which can be used to execute `rayon`-style work.
+
+use std::{cell::RefCell, rc::Rc};
+use wasm_bindgen::{prelude::*, JsCast};
+use web_sys::{DedicatedWorkerGlobalScope, ErrorEvent, Event, MessageEvent, Worker};
+
+macro_rules! console_log {
+    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = log)]
+    fn logv(x: &JsValue);
+}
+
+#[wasm_bindgen]
+pub struct WorkerProcess {
+    state: Rc<WorkerState>,
+}
+
+struct WorkerState {
+    workers: RefCell<Vec<Worker>>,
+    callback: Closure<dyn FnMut(Event)>,
+}
+
+struct Work {
+    func: Box<dyn FnOnce() + Send>,
+}
+
+#[wasm_bindgen]
+impl WorkerProcess {
+    /// Creates a new `WorkerProcess` which immediately creates `initial` workers.
+    ///
+    /// The pool created here can be used over a long period of time, and it
+    /// will be initially primed with `initial` workers. Currently workers are
+    /// never released or gc'd until the whole pool is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error that may happen while a JS web worker is created and a
+    /// message is sent to it.
+    #[wasm_bindgen(constructor)]
+    pub fn new(initial: usize) -> Result<WorkerProcess, JsValue> {
+        let pool = WorkerProcess {
+            state: Rc::new(WorkerState {
+                workers: RefCell::new(Vec::with_capacity(initial)),
+                callback: Closure::wrap(Box::new(|event: Event| {
+                    console_log!("unhandled event: {}", event.type_());
+                    crate::pool::logv(&event);
+                }) as Box<dyn FnMut(Event)>),
+            }),
+        };
+        for _ in 0..initial {
+            let worker = pool.spawn()?;
+            pool.state.push(worker);
+        }
+
+        Ok(pool)
+    }
+
+    /// Unconditionally spawns a new worker
+    ///
+    /// The worker isn't registered with this `WorkerPool` but is capable of
+    /// executing work for this wasm module.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error that may happen while a JS web worker is created and a
+    /// message is sent to it.
+    fn spawn(&self) -> Result<Worker, JsValue> {
+        // TODO: what do do about `./worker.js`:
+        //
+        // * the path is only known by the bundler. How can we, as a
+        //   library, know what's going on?
+        // * How do we not fetch a script N times? It internally then
+        //   causes another script to get fetched N times...
+        let worker = Worker::new("./worker.js")?;
+
+        // With a worker spun up send it the module/memory so it can start
+        // instantiating the wasm module. Later it might receive further
+        // messages about code to run on the wasm module.
+        let array = js_sys::Array::new();
+        array.push(&wasm_bindgen::module());
+        array.push(&wasm_bindgen::memory());
+        worker.post_message(&array)?;
+
+        Ok(worker)
+    }
+
+    /// Fetches a worker from this pool, spawning one if necessary.
+    ///
+    /// This will attempt to pull an already-spawned web worker from our cache
+    /// if one is available, otherwise it will spawn a new worker and return the
+    /// newly spawned worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error that may happen while a JS web worker is created and a
+    /// message is sent to it.
+    fn worker(&self) -> Result<Worker, JsValue> {
+        match self.state.workers.borrow_mut().pop() {
+            Some(worker) => Ok(worker),
+            None => self.spawn(),
+        }
+    }
+
+    /// Executes the work `f` in a web worker, spawning a web worker if
+    /// necessary.
+    ///
+    /// This will acquire a web worker and then send the closure `f` to the
+    /// worker to execute. The worker won't be usable for anything else while
+    /// `f` is executing, and no callbacks are registered for when the worker
+    /// finishes.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error that may happen while a JS web worker is created and a
+    /// message is sent to it.
+    fn execute(&self, f: impl FnOnce() + Send + 'static) -> Result<Worker, JsValue> {
+        let worker = self.worker()?;
+        let work = Box::new(Work { func: Box::new(f) });
+        let ptr = Box::into_raw(work);
+        match worker.post_message(&JsValue::from(ptr as u32)) {
+            Ok(()) => Ok(worker),
+            Err(e) => {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Configures an `onmessage` callback for the `worker` specified for the
+    /// web worker to be reclaimed and re-inserted into this pool when a message
+    /// is received.
+    ///
+    /// Currently this `WorkerPool` abstraction is intended to execute one-off
+    /// style work where the work itself doesn't send any notifications and
+    /// whatn it's done the worker is ready to execute more work. This method is
+    /// used for all spawned workers to ensure that when the work is finished
+    /// the worker is reclaimed back into this pool.
+    fn reclaim_on_message(&self, worker: Worker) {
+        let state = Rc::downgrade(&self.state);
+        let worker2 = worker.clone();
+        let reclaim_slot = Rc::new(RefCell::new(None));
+        let slot2 = reclaim_slot.clone();
+        let reclaim = Closure::wrap(Box::new(move |event: Event| {
+            if let Some(error) = event.dyn_ref::<ErrorEvent>() {
+                console_log!("error in worker: {}", error.message());
+                // TODO: this probably leaks memory somehow? It's sort of
+                // unclear what to do about errors in workers right now.
+                return;
+            }
+
+            // If this is a completion event then can deallocate our own
+            // callback by clearing out `slot2` which contains our own closure.
+            if let Some(_msg) = event.dyn_ref::<MessageEvent>() {
+                if let Some(state) = state.upgrade() {
+                    state.push(worker2.clone());
+                }
+                *slot2.borrow_mut() = None;
+                return;
+            }
+
+            console_log!("unhandled event: {}", event.type_());
+            crate::pool::logv(&event);
+            // TODO: like above, maybe a memory leak here?
+        }) as Box<dyn FnMut(Event)>);
+        worker.set_onmessage(Some(reclaim.as_ref().unchecked_ref()));
+        *reclaim_slot.borrow_mut() = Some(reclaim);
+    }
+}
+
+impl WorkerProcess {
+    /// Executes `f` in a web worker.
+    ///
+    /// This pool manages a set of web workers to draw from, and `f` will be
+    /// spawned quickly into one if the worker is idle. If no idle workers are
+    /// available then a new web worker will be spawned.
+    ///
+    /// Once `f` returns the worker assigned to `f` is automatically reclaimed
+    /// by this `WorkerPool`. This method provides no method of learning when
+    /// `f` completes, and for that you'll need to use `run_notify`.
+    ///
+    /// # Errors
+    ///
+    /// If an error happens while spawning a web worker or sending a message to
+    /// a web worker, that error is returned.
+    pub fn run(&self, f: impl FnOnce() + Send + 'static) -> Result<(), JsValue> {
+        let worker = self.execute(f)?;
+        self.reclaim_on_message(worker);
+        Ok(())
+    }
+}
+
+impl WorkerState {
+    fn push(&self, worker: Worker) {
+        worker.set_onmessage(Some(self.callback.as_ref().unchecked_ref()));
+        worker.set_onerror(Some(self.callback.as_ref().unchecked_ref()));
+        let mut workers = self.workers.borrow_mut();
+        for prev in workers.iter() {
+            let prev: &JsValue = prev;
+            let worker: &JsValue = &worker;
+            assert!(prev != worker);
+        }
+        workers.push(worker);
+    }
+}
+
+/// Entry point invoked by `worker.js`, a bit of a hack but see the "TODO" above
+/// about `worker.js` in general.
+#[wasm_bindgen]
+pub fn child_entry_point(ptr: u32) -> Result<(), JsValue> {
+    let ptr = unsafe { Box::from_raw(ptr as *mut Work) };
+    let global = js_sys::global().unchecked_into::<DedicatedWorkerGlobalScope>();
+    (ptr.func)();
+    global.post_message(&JsValue::undefined())?;
+    Ok(())
+}

--- a/phase1-wasm/src/requests.rs
+++ b/phase1-wasm/src/requests.rs
@@ -1,0 +1,254 @@
+use crate::utils::*;
+use js_sys::{Promise, Uint8Array};
+use rand::{CryptoRng, Rng};
+use setup1_shared::structures::LockResponse;
+use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, PrivateKey};
+use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+const MAJOR: u8 = 0;
+const MINOR: u8 = 1;
+const PATCH: u8 = 0;
+
+// A custom binding to the JS `fetch` function, which we use in place of `reqwest`
+// in cases where request payload may be malformed.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = fetch)]
+    fn fetch_with_request(input: &web_sys::Request) -> Promise;
+}
+
+/// Join the ceremony queue.
+///
+/// NOTE: This function makes use of the custom binding to `fetch`, since reqwest
+/// tends to malform payload blobs. The custom binding bypasses reqwest's
+/// serialization procedures and allows us to deliver the payload properly.
+pub async fn post_join_queue<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    confirmation_key: &str,
+    server_url: String,
+    rng: &mut R,
+) -> Result<bool, JsValue> {
+    let join_queue_path = format!("/v1/queue/contributor/join/{}/{}/{}", MAJOR, MINOR, PATCH);
+    let mut join_queue_url = server_url.clone();
+    join_queue_url.push_str(&join_queue_path);
+    let authorization = get_authorization_value(private_key, "POST", &join_queue_path, rng)?;
+
+    let bytes = serde_json::to_vec(confirmation_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+    let mut opts = RequestInit::new();
+    opts.method("POST");
+    opts.mode(RequestMode::Cors);
+    opts.body(Some(&js_sys::Uint8Array::from(bytes.as_slice()).into()));
+
+    let request = Request::new_with_str_and_init(&join_queue_url, &opts)?;
+
+    request.headers().set("Authorization", &authorization)?;
+    request.headers().set("Content-Length", &format!("{}", bytes.len()))?;
+    request.headers().set("Content-Type", "application/json")?;
+
+    let response = JsFuture::from(fetch_with_request(&request)).await?;
+
+    let response: Response = response.dyn_into().unwrap();
+    let data = JsFuture::from(response.json()?).await?;
+    let joined: bool = data.into_serde().unwrap();
+    Ok(joined)
+}
+
+/// Send a heartbeat to the coordinator, signaling that the contributor is still
+/// online.
+pub async fn post_heartbeat<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    let heartbeat_path = "/v1/contributor/heartbeat";
+    let mut heartbeat_url = server_url.clone();
+    heartbeat_url.push_str(&heartbeat_path);
+    let client = reqwest::Client::new();
+    let authorization = get_authorization_value(private_key, "POST", &heartbeat_path, rng)?;
+
+    let response = client
+        .post(&heartbeat_url)
+        .header(http::header::AUTHORIZATION, authorization)
+        .header(http::header::CONTENT_LENGTH, 0)
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    response
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    Ok(())
+}
+
+/// Inquire the coordinator about the existence of any unfinished tasks. Used to
+/// gauge when the contributor is finished.
+pub async fn get_tasks_left<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    rng: &mut R,
+) -> Result<bool, JsValue> {
+    let task_path = "/v1/contributor/get_task";
+    let mut task_url = server_url.clone();
+    task_url.push_str(&task_path);
+    let client = reqwest::Client::new();
+    let authorization = get_authorization_value(private_key, "GET", &task_path, rng)?;
+
+    let response = client
+        .post(&task_url)
+        .header(http::header::AUTHORIZATION, authorization)
+        .header(http::header::CONTENT_LENGTH, 0)
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    let data = response
+        .bytes()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    let tasks_left = serde_json::from_slice::<bool>(&*data).map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    Ok(tasks_left)
+}
+
+/// Lock a chunk in the ceremony. This should be the first function called when
+/// attempting to contribute to a chunk. Once the chunk is locked, it is ready
+/// to be downloaded.
+pub async fn post_lock_chunk<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    rng: &mut R,
+) -> Result<LockResponse, JsValue> {
+    let lock_path = "/v1/contributor/try_lock";
+    let mut lock_url = server_url.clone();
+    lock_url.push_str(&lock_path);
+    let client = reqwest::Client::new();
+    let authorization = get_authorization_value(private_key, "POST", &lock_path, rng)?;
+
+    let response = client
+        .post(&lock_url)
+        .header(http::header::AUTHORIZATION, authorization)
+        .header(http::header::CONTENT_LENGTH, 0)
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    let data = response
+        .bytes()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    let lock_response =
+        serde_json::from_slice::<LockResponse>(&*data).map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    Ok(lock_response)
+}
+
+/// Download a chunk from the coordinator, which should be contributed to upon
+/// receipt.
+///
+/// NOTE: This function makes use of the custom binding to `fetch`, since reqwest
+/// tends to malform response data. The custom binding bypasses reqwest's
+/// serialization procedures and allows us to deliver the payload properly.
+pub async fn get_challenge<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    contribution_id: u64,
+    rng: &mut R,
+) -> Result<Vec<u8>, JsValue> {
+    let download_path = format!("/v1/download/challenge/{}/{}", chunk_id, contribution_id);
+    let mut download_url = server_url.clone();
+    download_url.push_str(&download_path);
+    let authorization = get_authorization_value(private_key, "GET", &download_path, rng)?;
+
+    let mut opts = RequestInit::new();
+    opts.method("GET");
+    opts.mode(RequestMode::Cors);
+
+    let request = Request::new_with_str_and_init(&download_url, &opts)?;
+
+    request.headers().set("Authorization", &authorization)?;
+
+    let response = JsFuture::from(fetch_with_request(&request)).await?;
+
+    let response: Response = response.dyn_into().unwrap();
+    let chunk_bytes = JsFuture::from(response.array_buffer()?).await?;
+    let chunk_bytes = Uint8Array::new(&chunk_bytes);
+    Ok(chunk_bytes.to_vec())
+}
+
+/// Upload a chunk contribution to the coordinator.
+///
+/// NOTE: This function makes use of the custom binding to `fetch`, since reqwest
+/// tends to malform response upload blobs. The custom binding bypasses reqwest's
+/// serialization procedures and allows us to deliver the payload properly.
+pub async fn post_response<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    contribution_id: u64,
+    sig_and_result_bytes: Vec<u8>,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    let upload_path = format!("/v1/upload/response/{}/{}", chunk_id, contribution_id);
+    let mut upload_url = server_url.clone();
+    upload_url.push_str(&upload_path);
+    let authorization = get_authorization_value(private_key, "POST", &upload_path, rng)?;
+
+    let mut opts = RequestInit::new();
+    opts.method("POST");
+    opts.mode(RequestMode::Cors);
+    opts.body(Some(&js_sys::Uint8Array::from(sig_and_result_bytes.as_slice()).into()));
+
+    let request = Request::new_with_str_and_init(&upload_url, &opts)?;
+
+    request.headers().set("Authorization", &authorization)?;
+    request
+        .headers()
+        .set("Content-Length", &format!("{}", sig_and_result_bytes.len()))?;
+    request.headers().set("Content-Type", "application/octet-stream")?;
+
+    let _response = JsFuture::from(fetch_with_request(&request)).await?;
+
+    Ok(())
+}
+
+/// Notify the coordinator of a finished and uploaded contribution. This will
+/// unlock the given chunk and allow the contributor to take on a new task.
+pub async fn post_contribution<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    server_url: String,
+    chunk_id: u64,
+    rng: &mut R,
+) -> Result<(), JsValue> {
+    let contribute_path = format!("/v1/contributor/try_contribute/{}", chunk_id);
+    let mut contribute_url = server_url.clone();
+    contribute_url.push_str(&contribute_path);
+    let client = reqwest::Client::new();
+    let authorization = get_authorization_value(private_key, "POST", &contribute_path, rng)?;
+
+    let response = client
+        .post(&contribute_url)
+        .header(http::header::AUTHORIZATION, authorization)
+        .header(http::header::CONTENT_LENGTH, 0)
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    response
+        .error_for_status()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    Ok(())
+}

--- a/phase1-wasm/src/structures.rs
+++ b/phase1-wasm/src/structures.rs
@@ -1,0 +1,95 @@
+use crate::errors::ContributeError;
+use serde::{Deserialize, Serialize};
+use serde_diff::SerdeDiff;
+
+use wasm_bindgen::prelude::*;
+
+///
+/// The contribution state for a given chunk ID that is signed by the participant.
+///
+/// This state is comprised of:
+/// 1. The hash of the challenge file.
+/// 2. The hash of the response file.
+/// 3. The hash of the next challenge file if the participant was a verifier.
+///
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[serde(rename_all = "camelCase")]
+pub struct ContributionState {
+    /// The hash of the challenge file.
+    challenge_hash: String,
+    /// The hash of the response file.
+    response_hash: String,
+    /// The hash of the next challenge file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_challenge_hash: Option<String>,
+}
+
+impl ContributionState {
+    /// Creates a new instance of `ContributionFileSignature`.
+    pub fn new(
+        challenge_hash: Vec<u8>,
+        response_hash: Vec<u8>,
+        next_challenge_hash: Option<Vec<u8>>,
+    ) -> Result<Self, ContributeError> {
+        // Check that the challenge hash is 64 bytes.
+        if challenge_hash.len() != 64 {
+            return Err(ContributeError::ChallengeHashSizeInvalid);
+        }
+
+        // Check that the response hash is 64 bytes.
+        if response_hash.len() != 64 {
+            return Err(ContributeError::ResponseHashSizeInvalid);
+        }
+
+        // Check that the next challenge hash is 64 bytes, if it exists.
+        if let Some(next_challenge_hash) = &next_challenge_hash {
+            if next_challenge_hash.len() != 64 {
+                return Err(ContributeError::NextChallengeHashSizeInvalid);
+            }
+        }
+
+        Ok(ContributionState {
+            challenge_hash: hex::encode(challenge_hash),
+            response_hash: hex::encode(response_hash),
+            next_challenge_hash: next_challenge_hash.map(|h| hex::encode(h)),
+        })
+    }
+
+    /// Returns the message that should be signed for the `ContributionFileSignature`.
+    pub fn signature_message(&self) -> Result<String, JsValue> {
+        Ok(serde_json::to_string(&self).map_err(|e| JsValue::from_str(&format!("{}", e)))?)
+    }
+}
+
+///
+/// The signature and state of the contribution.
+///
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, SerdeDiff)]
+pub struct ContributionFileSignature {
+    /// The signature of the contribution state.
+    signature: String,
+    /// The state of the contribution that is signed.
+    state: ContributionState,
+}
+
+impl ContributionFileSignature {
+    /// Creates a new instance of `ContributionFileSignature`.
+    pub fn new(signature: String, state: ContributionState) -> Result<Self, JsValue> {
+        tracing::debug!("Starting to create contribution signature");
+        // Check that the signature is 64 bytes.
+        if hex::decode(&signature)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
+            .len()
+            != 64
+        {
+            return Err(ContributeError::ContributionSignatureSizeMismatch.into());
+        }
+        tracing::debug!("Completed creating contribution signature");
+        Ok(Self { signature, state })
+    }
+
+    /// Returns a reference to the signature.
+    pub fn get_signature(&self) -> &str {
+        &self.signature
+    }
+}

--- a/phase1-wasm/src/utils.rs
+++ b/phase1-wasm/src/utils.rs
@@ -1,0 +1,70 @@
+use crate::structures::*;
+use blake2::{Blake2b, Digest};
+use rand::{CryptoRng, Rng};
+use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, Address, PrivateKey, ViewKey};
+use snarkvm_utilities::ToBytes;
+use std::convert::TryFrom;
+use wasm_bindgen::prelude::*;
+
+/// Construct the authentication string for requests made to the coordinator.
+pub fn get_authorization_value<R: Rng + CryptoRng>(
+    private_key: &PrivateKey<Testnet2Parameters>,
+    method: &str,
+    path: &str,
+    rng: &mut R,
+) -> Result<String, JsValue> {
+    let view_key = ViewKey::try_from(private_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+    let address = Address::try_from(private_key)
+        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
+        .to_string();
+
+    let message = format!("{} {}", method.to_lowercase(), path.to_lowercase());
+    let signature = hex::encode(
+        &view_key
+            .sign(message.as_bytes(), rng)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
+            .to_bytes_le()
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?,
+    );
+
+    let authorization = format!("Aleo {}:{}", address, signature);
+    Ok(authorization)
+}
+
+pub fn sign_contribution_state<R: Rng + CryptoRng>(
+    signing_key: &PrivateKey<Testnet2Parameters>,
+    challenge_hash: &[u8],
+    response_hash: &[u8],
+    next_challenge_hash: Option<Vec<u8>>,
+    rng: &mut R,
+) -> Result<ContributionFileSignature, JsValue> {
+    let contribution_state =
+        ContributionState::new(challenge_hash.to_vec(), response_hash.to_vec(), next_challenge_hash)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+    let message = contribution_state
+        .signature_message()
+        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+    let view_key = ViewKey::try_from(signing_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+    let signature = hex::encode(
+        &view_key
+            .sign(message.as_bytes(), rng)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
+            .to_bytes_le()
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?,
+    );
+
+    let contribution_file_signature = ContributionFileSignature::new(signature, contribution_state)
+        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+    Ok(contribution_file_signature)
+}
+
+pub fn calculate_hash(input_map: &[u8]) -> Vec<u8> {
+    let chunk_size = 1 << 30; // read by 1GB from map
+    let mut hasher = Blake2b::default();
+    for chunk in input_map.chunks(chunk_size) {
+        hasher.update(&chunk);
+    }
+    hasher.finalize().to_vec()
+}

--- a/phase1/Cargo.toml
+++ b/phase1/Cargo.toml
@@ -38,6 +38,7 @@ snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = { version = "1.0.37" }
 blake2 = { version = "0.9", default-features = false }
+memmap = { version = "0.7.0" }
 num-traits = { version = "0.2.12" }
 rand_chacha = { version = "0.3" }
 rusty-hook = { version = "0.11.2" }

--- a/phase2/Cargo.toml
+++ b/phase2/Cargo.toml
@@ -50,7 +50,7 @@ phase2 = { path = "./", features = ["testing"] }
 wasm-bindgen-test = { version = "0.3.18" }
 
 rusty-hook = { version = "0.11.2" }
-tracing-subscriber = { version = "0.2.3" }
+tracing-subscriber = { version = "0.3" }
 
 [features]
 default = []

--- a/setup-utils/Cargo.toml
+++ b/setup-utils/Cargo.toml
@@ -31,8 +31,8 @@ num_cpus = { version = "1.12.0" }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
 rayon = { version = "1.4.1", optional = true }
-rust-crypto = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.9.8"
 thiserror = { version = "1.0.22" }
 tracing = { version = "0.1.21" }
 
@@ -44,6 +44,6 @@ rusty-hook = { version = "0.11.2" }
 
 [features]
 default = []
-cli = ["parallel", "rust-crypto"]
+cli = ["parallel"]
 wasm = ["snarkvm-algorithms/wasm"]
 parallel = ["rayon", "snarkvm-algorithms/parallel"]

--- a/setup-utils/Cargo.toml
+++ b/setup-utils/Cargo.toml
@@ -25,6 +25,7 @@ blake2s_simd = { version = "0.5.11" }
 cfg-if = "1.0"
 crossbeam = { version = "0.8.0" }
 generic-array = { version = "0.14", features = ["more_lengths"] }
+futures = "0.3"
 hex = { version = "0.4.3" }
 num_cpus = { version = "1.12.0" }
 rand = { version = "0.8" }
@@ -45,4 +46,4 @@ rusty-hook = { version = "0.11.2" }
 default = []
 cli = ["parallel", "rust-crypto"]
 wasm = ["snarkvm-algorithms/wasm"]
-parallel = ["rayon", "snarkvm-algorithms/parallel", "rust-crypto"]
+parallel = ["rayon", "snarkvm-algorithms/parallel"]

--- a/setup-utils/src/helpers.rs
+++ b/setup-utils/src/helpers.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 #[cfg(not(feature = "wasm"))]
-use crypto::{digest::Digest as CryptoDigest, sha2::Sha256};
+use sha2::Sha256;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -139,8 +139,9 @@ pub fn beacon_randomness(mut beacon_hash: [u8; 32]) -> [u8; 32] {
         }
 
         let mut h = Sha256::new();
-        h.input(&beacon_hash);
-        h.result(&mut beacon_hash);
+        h.update(&beacon_hash);
+        let result = h.finalize();
+        beacon_hash.copy_from_slice(&result);
     }
 
     print!("Final result of beacon: ");

--- a/setup1-cli-tools/Cargo.toml
+++ b/setup1-cli-tools/Cargo.toml
@@ -16,10 +16,10 @@ path = "src/view_key.rs"
 snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM", rev = "fc997c" }
 
 anyhow = "1.0.38"
-age = { version = "0.6", features = ["cli-common", "armor"] }
+age = { version = "0.7", features = ["cli-common", "armor", "plugin"] }
 hex = "0.4"
 rand = "0.8"
-secrecy = "0.7"
+secrecy = "0.8"
 serde = "1.0.123"
 serde_json = "1.0.64"
 structopt = "0.3.21"

--- a/setup1-contributor/Cargo.toml
+++ b/setup1-contributor/Cargo.toml
@@ -18,39 +18,33 @@ snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM", rev = "fc997c" }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
-age = { version = "0.6", features = [ "cli-common", "armor" ] }
+age = { version = "0.7", features = [ "cli-common", "armor", "plugin" ] }
 anyhow = { version = "1.0.33" }
 blake2 = "0.9"
 clap = { version = "2.33.3" }
-dialoguer = "0.8"
+dialoguer = "0.9"
 egg-mode = "0.16"
 fs-err = "2.6"
 futures = { version = "0.3" }
 futures-util = { version = "0.3.15", default-features = false, features = ["async-await", "sink", "std"] }
 hex = { version = "0.4" }
 http = "0.2"
-i18n-embed = { version = "0.9", features = ["desktop-requester"] }
-indicatif = { version = "0.15.0" }
+i18n-embed = { version = "0.13", features = ["desktop-requester"] }
+indicatif = { version = "0.16" }
 panic-control = {version = "0.1.4" }
 rand = { version = "0.8" }
 regex = "1"
 reqwest = "0.11"
-secrecy = { version = "0.7" }
+secrecy = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serial_test = { version = "0.5.1" }
 structopt = { version = "0.3" }
 thiserror = { version = "1.0" }
-tokio = { version = "1.7", features = [ "macros", "rt-multi-thread" ] }
+tokio = { version = "1.13", features = [ "macros", "rt-multi-thread" ] }
+tokio-tungstenite = { version = "0.15.0", features = ["native-tls"] }
 tracing = { version = "0.1" }
-tracing-appender = { version = "0.1.1" }
-tracing-subscriber = { version = "0.2" }
-url = { version = "2.1.1" }
+tracing-appender = { version = "0.2" }
+tracing-subscriber = { version = "0.3" }
+url = { version = "2.2" }
 
-[dependencies.tokio-tungstenite]
-version = "0.15.0"
-# remove gh link after the new version is released
-# related issue: https://github.com/snapview/tokio-tungstenite/issues/182
-git = "https://github.com/snapview/tokio-tungstenite"
-rev = "2bfd4cd"
-features = ["native-tls"]

--- a/setup1-contributor/src/objects.rs
+++ b/setup1-contributor/src/objects.rs
@@ -15,42 +15,6 @@ pub struct SignedVerifiedData {
     pub signature: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Hash, Clone, PartialEq, Eq)]
-pub struct LockResponse {
-    /// The chunk id
-    #[serde(alias = "chunkId")]
-    pub chunk_id: u64,
-
-    /// The contribution id
-    #[serde(alias = "contributionId")]
-    pub contribution_id: u64,
-
-    /// Indicator if the chunk was locked
-    pub locked: bool,
-
-    /// The participant id related to the lock
-    #[serde(alias = "participantId")]
-    pub participant_id: String,
-
-    /// The locator of the previous response
-    #[serde(alias = "previousResponseLocator")]
-    pub previous_response_locator: String,
-
-    /// The locator of the challenge file that the participant will download
-    #[serde(alias = "challengeLocator")]
-    pub challenge_locator: String,
-
-    /// The locator where the participant will upload their completed contribution.
-    #[serde(alias = "responseLocator")]
-    pub response_locator: String,
-
-    #[serde(alias = "responseChunkId")]
-    pub response_chunk_id: u64,
-
-    #[serde(alias = "responseContributionId")]
-    pub response_contribution_id: u64,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ContributedData {

--- a/setup1-contributor/src/setup_keys/mod.rs
+++ b/setup1-contributor/src/setup_keys/mod.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use age::{
     armor::{ArmoredWriter, Format},
     cli_common::Passphrase,
-    EncryptError,
     Encryptor,
 };
 use anyhow::Result;
@@ -32,11 +31,7 @@ struct UnencryptedKeys {
 fn encrypt(passphrase: SecretString, secret: &[u8]) -> Result<String> {
     let encryptor = Encryptor::with_user_passphrase(passphrase);
     let mut encrypted_output = vec![];
-    let mut writer = encryptor
-        .wrap_output(ArmoredWriter::wrap_output(&mut encrypted_output, Format::Binary)?)
-        .map_err(|e| match e {
-            EncryptError::Io(e) => e,
-        })?;
+    let mut writer = encryptor.wrap_output(ArmoredWriter::wrap_output(&mut encrypted_output, Format::Binary)?)?;
     writer.write_all(secret)?;
     writer.finish()?;
     let encrypted_secret = hex::encode(&encrypted_output);

--- a/setup1-shared/Cargo.toml
+++ b/setup1-shared/Cargo.toml
@@ -19,4 +19,4 @@ snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"
 egg-mode = { version = "0.16", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.9", features = ["io-util"], optional = true }
+tokio = { version = "1.13", features = ["io-util"], optional = true }

--- a/setup1-shared/src/structures.rs
+++ b/setup1-shared/src/structures.rs
@@ -63,3 +63,39 @@ pub enum ContributorStatus {
     Finished,
     Other,
 }
+
+#[derive(Serialize, Deserialize, Debug, Hash, Clone, PartialEq, Eq)]
+pub struct LockResponse {
+    /// The chunk id
+    #[serde(alias = "chunkId")]
+    pub chunk_id: u64,
+
+    /// The contribution id
+    #[serde(alias = "contributionId")]
+    pub contribution_id: u64,
+
+    /// Indicator if the chunk was locked
+    pub locked: bool,
+
+    /// The participant id related to the lock
+    #[serde(alias = "participantId")]
+    pub participant_id: String,
+
+    /// The locator of the previous response
+    #[serde(alias = "previousResponseLocator")]
+    pub previous_response_locator: String,
+
+    /// The locator of the challenge file that the participant will download
+    #[serde(alias = "challengeLocator")]
+    pub challenge_locator: String,
+
+    /// The locator where the participant will upload their completed contribution.
+    #[serde(alias = "responseLocator")]
+    pub response_locator: String,
+
+    #[serde(alias = "responseChunkId")]
+    pub response_chunk_id: u64,
+
+    #[serde(alias = "responseContributionId")]
+    pub response_contribution_id: u64,
+}

--- a/setup1-verifier/Cargo.toml
+++ b/setup1-verifier/Cargo.toml
@@ -21,7 +21,6 @@ snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"
 snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM", rev = "fc997c" }
 
 anyhow = { version = "1.0.32" }
-chrono = { version = "0.4", features = ["serde"] }
 ctrlc = { version = "3.1.7" }
 fs-err = { version = "2.6" }
 futures-util = { version = "0.3.5" }
@@ -33,9 +32,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 structopt = "0.3.21"
 thiserror = { version = "1.0" }
-tokio = { version = "1.9", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.26" }
-tracing-subscriber = { version = "0.2" }
+tracing-subscriber = { version = "0.3" }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/setup2/Cargo.toml
+++ b/setup2/Cargo.toml
@@ -30,7 +30,7 @@ memmap = { version = "0.7.0", optional = true }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
 thiserror = { version = "1.0.22" }
-tracing-subscriber = { version = "0.2.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 
 [features]
 default = ["cli"]

--- a/setup2/src/main.rs
+++ b/setup2/src/main.rs
@@ -11,12 +11,12 @@ cfg_if! {
         use std::{process, time::Instant};
         use tracing_subscriber::{
             filter::EnvFilter,
-            fmt::{time::ChronoUtc, Subscriber},
+            fmt::{time, Subscriber},
         };
 
         fn main() {
             Subscriber::builder()
-                .with_timer(ChronoUtc::rfc3339())
+                .with_timer(time::UtcTime::rfc_3339())
                 .with_env_filter(EnvFilter::from_default_env())
                 .init();
             let opts = SNARKOpts::parse_args_default_or_exit();


### PR DESCRIPTION
As `master` is protected, it first needs to be merged into a clone of `phase2` because of the conflicts in #447. Supersedes #447.