### PR TITLE
Remove the dependency on `rust-crypto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,12 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,12 +990,6 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generator"
@@ -2116,29 +2104,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2181,21 +2146,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2265,15 +2215,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2366,19 +2307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time 0.1.43",
-]
-
-[[package]]
 name = "rust-embed"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,12 +2345,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
@@ -2729,9 +2651,9 @@ dependencies = [
  "rand 0.8.4",
  "rand_chacha 0.3.1",
  "rayon",
- "rust-crypto",
  "rusty-hook",
  "serde",
+ "sha2",
  "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",

--- a/setup-utils/Cargo.toml
+++ b/setup-utils/Cargo.toml
@@ -30,7 +30,6 @@ num_cpus = { version = "1.12.0" }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
 rayon = { version = "1.4.1", optional = true }
-rust-crypto = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9.8"
 thiserror = { version = "1.0.22" }
@@ -45,6 +44,6 @@ rusty-hook = { version = "0.11.2" }
 
 [features]
 default = []
-cli = ["parallel", "rust-crypto"]
+cli = ["parallel"]
 wasm = ["snarkvm-algorithms/wasm"]
 parallel = ["rayon", "snarkvm-algorithms/parallel"]

--- a/setup-utils/Cargo.toml
+++ b/setup-utils/Cargo.toml
@@ -32,6 +32,7 @@ rand_chacha = { version = "0.3" }
 rayon = { version = "1.4.1", optional = true }
 rust-crypto = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.9.8"
 thiserror = { version = "1.0.22" }
 tracing = { version = "0.1.21" }
 typenum = { version = "1.11.2" }

--- a/setup-utils/src/helpers.rs
+++ b/setup-utils/src/helpers.rs
@@ -20,7 +20,7 @@ use std::{
 use typenum::consts::U64;
 
 #[cfg(not(feature = "wasm"))]
-use crypto::{digest::Digest as CryptoDigest, sha2::Sha256};
+use sha2::Sha256;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -141,8 +141,9 @@ pub fn beacon_randomness(mut beacon_hash: [u8; 32]) -> [u8; 32] {
         }
 
         let mut h = Sha256::new();
-        h.input(&beacon_hash);
-        h.result(&mut beacon_hash);
+        h.update(&beacon_hash);
+        let result = h.finalize();
+        beacon_hash.copy_from_slice(&result);
     }
 
     print!("Final result of beacon: ");


### PR DESCRIPTION
Removes the dependency as it is currently unmaintained and replaces it with `sha2`. 

Supersedes #434. 