### PR TITLE
Revert "Remove the dependency on `chrono`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-humanize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "ci_info"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1829,8 @@ name = "phase1-coordinator"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "chrono-humanize",
  "fs-err",
  "futures",
  "hex",
@@ -1838,7 +1849,6 @@ dependencies = [
  "setup-utils",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",
- "time 0.3.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2564,6 +2574,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
+ "chrono",
  "rustversion",
  "serde",
  "serde_with_macros",
@@ -3415,15 +3426,7 @@ checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",
- "serde",
- "time-macros",
 ]
-
-[[package]]
-name = "time-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinystr"

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -19,6 +19,8 @@ setup-utils = { path = "../setup-utils" }
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = { version = "1.0.37" }
+chrono = { version = "0.4", features = ["serde"] }
+chrono-humanize = { version = "0.2" }
 fs-err = { version = "2.6.0" }
 itertools = "0.10"
 futures = { version = "0.3" }
@@ -31,9 +33,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde-aux = { version = "3.0" }
 serde-diff = { version = "0.4" }
 serde_json = { version = "1.0" }
-serde_with = { version = "1.8", features = ["macros"] }
+serde_with = { version = "1.8", features = ["chrono", "macros"] }
 thiserror = { version = "1.0" }
-time = { version = "0.3", features = ["serde-human-readable", "macros"] }
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time", "sync", "signal"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }

--- a/phase1-coordinator/src/commands/aggregation.rs
+++ b/phase1-coordinator/src/commands/aggregation.rs
@@ -154,9 +154,9 @@ mod tests {
         Coordinator,
     };
 
+    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
-    use time::OffsetDateTime;
     use tracing::*;
 
     #[test]
@@ -175,7 +175,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
+            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/commands/verification.rs
+++ b/phase1-coordinator/src/commands/verification.rs
@@ -354,9 +354,9 @@ mod tests {
         Coordinator,
     };
 
+    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
-    use time::OffsetDateTime;
 
     #[test]
     #[serial]
@@ -374,7 +374,7 @@ mod tests {
         {
             // Run initialization.
             info!("Initializing ceremony");
-            let round_height = coordinator.run_initialization(OffsetDateTime::now_utc()).unwrap();
+            let round_height = coordinator.run_initialization(Utc::now()).unwrap();
             info!("Initialized ceremony");
 
             // Check current round height is now 0.

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -30,12 +30,12 @@ use crate::{
 };
 use setup_utils::calculate_hash;
 
+use chrono::{DateTime, Utc};
 use std::{
     fmt,
     net::IpAddr,
     sync::{Arc, RwLock},
 };
-use time::OffsetDateTime;
 use tracing::*;
 
 #[cfg(any(test, feature = "operator"))]
@@ -281,7 +281,7 @@ impl From<CoordinatorError> for anyhow::Error {
 /// for mocking system time during testing.
 pub trait TimeSource: Send + Sync {
     /// Provide the current time now in the UTC timezone
-    fn now_utc(&self) -> OffsetDateTime;
+    fn utc_now(&self) -> DateTime<Utc>;
 }
 
 // Private tuple field to force use of constructor.
@@ -296,39 +296,39 @@ impl SystemTimeSource {
 }
 
 impl TimeSource for SystemTimeSource {
-    fn now_utc(&self) -> OffsetDateTime {
-        OffsetDateTime::now_utc()
+    fn utc_now(&self) -> DateTime<Utc> {
+        Utc::now()
     }
 }
 
 /// A time source to use for testing, allows the current time to be
 /// set manually.
 pub struct MockTimeSource {
-    time: RwLock<OffsetDateTime>,
+    time: RwLock<DateTime<Utc>>,
 }
 
 impl MockTimeSource {
-    pub fn new(time: OffsetDateTime) -> Self {
+    pub fn new(time: DateTime<Utc>) -> Self {
         Self {
             time: RwLock::new(time),
         }
     }
 
-    pub fn set_time(&self, time: OffsetDateTime) {
+    pub fn set_time(&self, time: DateTime<Utc>) {
         *self.time.write().expect("Unable to lock to write time") = time;
     }
 
-    pub fn time(&self) -> OffsetDateTime {
+    pub fn time(&self) -> DateTime<Utc> {
         *self.time.read().expect("Unable to obtain lock to read time")
     }
 
-    pub fn update<F: Fn(OffsetDateTime) -> OffsetDateTime>(&self, f: F) {
+    pub fn update<F: Fn(DateTime<Utc>) -> DateTime<Utc>>(&self, f: F) {
         self.set_time(f(self.time()))
     }
 }
 
 impl TimeSource for MockTimeSource {
-    fn now_utc(&self) -> OffsetDateTime {
+    fn utc_now(&self) -> DateTime<Utc> {
         *self.time.read().expect("Unable to obtain lock to read time")
     }
 }
@@ -418,7 +418,7 @@ impl Coordinator {
             // Check if the ceremony has been initialized yet.
             if Self::load_current_round_height(&self.storage).is_err() {
                 info!("Initializing ceremony");
-                let round_height = self.run_initialization(self.time.now_utc())?;
+                let round_height = self.run_initialization(self.time.utc_now())?;
                 info!("Initialized ceremony");
 
                 // Initialize the coordinator state to round 0.
@@ -532,7 +532,7 @@ impl Coordinator {
             // Backup a copy of the current coordinator.
 
             // Fetch the current time.
-            let started_at = self.time.now_utc();
+            let started_at = self.time.utc_now();
 
             // Attempt to advance to the next round.
             let next_round_height = self.try_advance(started_at)?;
@@ -582,7 +582,7 @@ impl Coordinator {
     /// Returns a list of the contributors currently in the queue.
     ///
     #[inline]
-    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime))> {
+    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>))> {
         self.state.queue_contributors()
     }
 
@@ -1275,7 +1275,7 @@ impl Coordinator {
     /// Attempts to advance the ceremony to the next round.
     ///
     #[tracing::instrument(skip(self, started_at))]
-    pub fn try_advance(&mut self, started_at: OffsetDateTime) -> Result<u64, CoordinatorError> {
+    pub fn try_advance(&mut self, started_at: DateTime<Utc>) -> Result<u64, CoordinatorError> {
         tracing::debug!("Trying to advance to the next round.");
 
         // Check that the current round height matches in storage and self.
@@ -1954,7 +1954,7 @@ impl Coordinator {
     #[inline]
     pub(crate) fn next_round(
         &mut self,
-        started_at: OffsetDateTime,
+        started_at: DateTime<Utc>,
         contributors: Vec<Participant>,
     ) -> Result<u64, CoordinatorError> {
         // Check that the next round has at least one authorized contributor.
@@ -2047,7 +2047,7 @@ impl Coordinator {
     /// and run `Initialization` to start the ceremony.
     ///
     #[inline]
-    pub(super) fn run_initialization(&mut self, started_at: OffsetDateTime) -> Result<u64, CoordinatorError> {
+    pub(super) fn run_initialization(&mut self, started_at: DateTime<Utc>) -> Result<u64, CoordinatorError> {
         // Check that the ceremony has not begun yet.
         if Self::load_current_round_height(&self.storage).is_ok() {
             return Err(CoordinatorError::RoundAlreadyInitialized);
@@ -2128,7 +2128,7 @@ impl Coordinator {
         }
 
         // Set the finished time for round 0.
-        round.try_finish(self.time.now_utc());
+        round.try_finish(self.time.utc_now());
 
         // Add the new round to storage.
         self.storage
@@ -2659,6 +2659,7 @@ mod tests {
         Coordinator,
     };
 
+    use chrono::Utc;
     use once_cell::sync::Lazy;
     use rand::RngCore;
     use std::{
@@ -2666,7 +2667,6 @@ mod tests {
         net::{IpAddr, Ipv4Addr},
         sync::Arc,
     };
-    use time::OffsetDateTime;
 
     fn initialize_to_round_1(
         coordinator: &mut Coordinator,
@@ -2759,7 +2759,7 @@ mod tests {
 
         // Check that round 0 matches the round 0 JSON specification.
         {
-            let now = OffsetDateTime::now_utc();
+            let now = Utc::now();
 
             // Fetch round 0 from coordinator.
             let mut expected = test_round_0_json()?;
@@ -3398,7 +3398,7 @@ mod tests {
             coordinator.aggregate_contributions()?;
 
             // Run aggregation and transition from round 1 to round 2.
-            coordinator.next_round(OffsetDateTime::now_utc(), vec![contributor.clone()])?;
+            coordinator.next_round(Utc::now(), vec![contributor.clone()])?;
         }
 
         // Check that the ceremony has advanced to round 2.

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use phase1::ProvingSystem;
 
+use chrono::{DateTime, Duration, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -17,7 +18,6 @@ use std::{
     iter::FromIterator,
     net::IpAddr,
 };
-use time::{Duration, OffsetDateTime};
 use tracing::*;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,7 +37,7 @@ pub struct ChunkLock {
     /// The id of the chunk which is locked.
     chunk_id: u64,
     /// The time that the chunk was locked.
-    lock_time: OffsetDateTime,
+    lock_time: DateTime<Utc>,
 }
 
 impl ChunkLock {
@@ -46,7 +46,7 @@ impl ChunkLock {
     pub fn new(chunk_id: u64, time: &dyn TimeSource) -> Self {
         Self {
             chunk_id,
-            lock_time: time.now_utc(),
+            lock_time: time.utc_now(),
         }
     }
 
@@ -56,7 +56,7 @@ impl ChunkLock {
     }
 
     /// The time that the chunk was locked.
-    pub fn lock_time(&self) -> &OffsetDateTime {
+    pub fn lock_time(&self) -> &DateTime<Utc> {
         &self.lock_time
     }
 }
@@ -72,15 +72,15 @@ pub struct ParticipantInfo {
     /// The bucket ID that this participant starts contributing from.
     bucket_id: u64,
     /// The timestamp of the first seen instance of this participant.
-    first_seen: OffsetDateTime,
+    first_seen: DateTime<Utc>,
     /// The timestamp of the last seen instance of this participant.
-    last_seen: OffsetDateTime,
+    last_seen: DateTime<Utc>,
     /// The timestamp when this participant started the round.
-    started_at: Option<OffsetDateTime>,
+    started_at: Option<DateTime<Utc>>,
     /// The timestamp when this participant finished the round.
-    finished_at: Option<OffsetDateTime>,
+    finished_at: Option<DateTime<Utc>>,
     /// The timestamp when this participant was dropped from the round.
-    dropped_at: Option<OffsetDateTime>,
+    dropped_at: Option<DateTime<Utc>>,
     /// A map of chunk IDs to locks on chunks that this participant currently holds.
     locked_chunks: HashMap<u64, ChunkLock>,
     /// The list of (chunk ID, contribution ID) tasks that this participant is assigned to compute.
@@ -111,7 +111,7 @@ impl ParticipantInfo {
         time: &dyn TimeSource,
     ) -> Self {
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
         Self {
             id: participant,
             round_height,
@@ -317,7 +317,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         // Update the last seen time.
         self.last_seen = now;
@@ -380,7 +380,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Add the task to the front of the pending tasks.
         self.assigned_tasks.push_front(task);
@@ -417,7 +417,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Fetch the next task in order as stored.
         match self.assigned_tasks.pop_front() {
@@ -483,7 +483,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         let chunk_lock = ChunkLock::new(chunk_id, time);
 
@@ -544,7 +544,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&task.chunk_id());
@@ -623,7 +623,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Remove the task from the pending tasks.
         self.pending_tasks = self
@@ -699,7 +699,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&task.chunk_id());
@@ -767,7 +767,7 @@ impl ParticipantInfo {
         }
 
         // Update the last seen time.
-        self.last_seen = time.now_utc();
+        self.last_seen = time.utc_now();
 
         // Remove the given chunk ID from the locked chunks.
         self.locked_chunks.remove(&chunk_id);
@@ -804,7 +804,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         // Set the participant info to reflect them dropping now.
         self.dropped_at = Some(now);
@@ -860,7 +860,7 @@ impl ParticipantInfo {
         }
 
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         // Update the last seen time.
         self.last_seen = now;
@@ -900,9 +900,9 @@ pub struct RoundMetrics {
     /// The average seconds per task calculated from all current verifiers.
     verifier_average_per_task: Option<u64>,
     /// The timestamp when the coordinator started aggregation of the current round.
-    started_aggregation_at: Option<OffsetDateTime>,
+    started_aggregation_at: Option<DateTime<Utc>>,
     /// The timestamp when the coordinator finished aggregation of the current round.
-    finished_aggregation_at: Option<OffsetDateTime>,
+    finished_aggregation_at: Option<DateTime<Utc>>,
     /// The estimated number of seconds remaining for the current round to finish.
     estimated_finish_time: Option<u64>,
     /// The estimated number of seconds remaining for the current round to aggregate.
@@ -910,7 +910,7 @@ pub struct RoundMetrics {
     /// The estimated number of seconds remaining until the queue is closed for the next round.
     estimated_wait_time: Option<u64>,
     /// The timestamp of the earliest start time for the next round.
-    next_round_after: Option<OffsetDateTime>,
+    next_round_after: Option<DateTime<Utc>>,
 }
 
 impl Default for RoundMetrics {
@@ -941,7 +941,7 @@ pub struct CoordinatorState {
     status: CoordinatorStatus,
     /// The map of queue participants with a reliability score, an assigned future
     /// round, a last seen timestamp, and their time of joining.
-    queue: HashMap<Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime)>,
+    queue: HashMap<Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>)>,
     /// The map of unique participants for the next round.
     next: HashMap<Participant, ParticipantInfo>,
     /// The metrics for the current round of the ceremony.
@@ -1072,8 +1072,8 @@ impl CoordinatorState {
 
             let current_metrics = Some(RoundMetrics {
                 is_round_aggregated: true,
-                started_aggregation_at: Some(time.now_utc()),
-                finished_aggregation_at: Some(time.now_utc()),
+                started_aggregation_at: Some(time.utc_now()),
+                finished_aggregation_at: Some(time.utc_now()),
                 ..Default::default()
             });
 
@@ -1086,8 +1086,8 @@ impl CoordinatorState {
                     (
                         participant_info.reliability,
                         Some(participant_info.round_height),
-                        time.now_utc(),
-                        time.now_utc(),
+                        time.utc_now(),
+                        time.utc_now(),
                     ),
                 );
             }
@@ -1294,7 +1294,7 @@ impl CoordinatorState {
     pub fn queue_contributor_info(
         &self,
         participant: &Participant,
-    ) -> Option<&(u8, Option<u64>, OffsetDateTime, OffsetDateTime)> {
+    ) -> Option<&(u8, Option<u64>, DateTime<Utc>, DateTime<Utc>)> {
         self.queue.get(participant)
     }
 
@@ -1302,7 +1302,7 @@ impl CoordinatorState {
     /// Returns a list of the contributors currently in the queue.
     ///
     #[inline]
-    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, OffsetDateTime, OffsetDateTime))> {
+    pub fn queue_contributors(&self) -> Vec<(Participant, (u8, Option<u64>, DateTime<Utc>, DateTime<Utc>))> {
         self.queue
             .clone()
             .into_par_iter()
@@ -1440,7 +1440,7 @@ impl CoordinatorState {
         // Check that the time to trigger the next round has been reached.
         if let Some(metrics) = &self.current_metrics {
             if let Some(next_round_after) = metrics.next_round_after {
-                if time.now_utc() < next_round_after {
+                if time.utc_now() < next_round_after {
                     trace!("Required queue wait time has not been reached yet");
                     return false;
                 }
@@ -1544,7 +1544,7 @@ impl CoordinatorState {
 
         // Add the participant to the queue.
         self.queue
-            .insert(participant, (reliability_score, None, time.now_utc(), time.now_utc()));
+            .insert(participant, (reliability_score, None, time.utc_now(), time.utc_now()));
 
         Ok(())
     }
@@ -1922,7 +1922,7 @@ impl CoordinatorState {
             };
 
             // Add the given task with a new start timer.
-            updated_tasks.insert(*task, (time.now_utc().unix_timestamp(), None));
+            updated_tasks.insert(*task, (time.utc_now().timestamp(), None));
 
             // Set the current task timer for the given participant to the updated task timer.
             metrics.task_timer.insert(participant.clone(), updated_tasks);
@@ -1954,7 +1954,7 @@ impl CoordinatorState {
             match updated_tasks.get_mut(task) {
                 Some((_, end)) => {
                     if end.is_none() {
-                        *end = Some(time.now_utc().unix_timestamp());
+                        *end = Some(time.utc_now().timestamp());
                     }
                 }
                 None => {
@@ -1992,7 +1992,7 @@ impl CoordinatorState {
         }
 
         // Set the start aggregation timestamp to now.
-        metrics.started_aggregation_at = Some(time.now_utc());
+        metrics.started_aggregation_at = Some(time.utc_now());
 
         Ok(())
     }
@@ -2024,7 +2024,7 @@ impl CoordinatorState {
         metrics.is_round_aggregated = true;
 
         // Set the finish aggregation timestamp to now.
-        metrics.finished_aggregation_at = Some(time.now_utc());
+        metrics.finished_aggregation_at = Some(time.utc_now());
 
         // Update the time to trigger the next round.
         if metrics.next_round_after.is_none() {
@@ -2039,7 +2039,7 @@ impl CoordinatorState {
     fn update_next_round_after(&mut self, time: &dyn TimeSource) {
         if let Some(metrics) = &mut self.current_metrics {
             metrics.next_round_after =
-                Some(time.now_utc() + Duration::seconds(self.environment.queue_wait_time() as i64));
+                Some(time.utc_now() + Duration::seconds(self.environment.queue_wait_time() as i64));
         }
     }
 
@@ -2593,7 +2593,7 @@ impl CoordinatorState {
     pub(super) fn update_dropped_queued_participants(&mut self, time: &dyn TimeSource) -> Result<(), CoordinatorError> {
         let queue_seen_timeout = self.environment.queue_seen_timeout();
 
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         for (participant, (_, _, last_seen, _)) in self.queue.clone() {
             if now - last_seen > queue_seen_timeout {
@@ -2616,7 +2616,7 @@ impl CoordinatorState {
         let participant_lock_timeout = self.environment.participant_lock_timeout();
 
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         self.current_contributors
             .clone()
@@ -2637,10 +2637,10 @@ impl CoordinatorState {
                     let exceeded_chunks_string: String = exceeded_chunk_names.join(", ");
 
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
+                        "Dropping participant {} because it has exceeded the maximum ({}) allowed time \
                         it is allowed to hold a lock (on chunks {}).",
                         participant,
-                        participant_lock_timeout.whole_seconds(),
+                        chrono_humanize::HumanTime::from(participant_lock_timeout),
                         exceeded_chunks_string,
                     );
                     Some(self.drop_participant(participant, time))
@@ -2662,7 +2662,7 @@ impl CoordinatorState {
         let contributor_seen_timeout = self.environment.contributor_seen_timeout();
 
         // Fetch the current time.
-        let now = time.now_utc();
+        let now = time.utc_now();
 
         self.current_contributors
             .clone()
@@ -2674,11 +2674,11 @@ impl CoordinatorState {
                 // Check if the participant is still live and not a coordinator contributor.
                 if elapsed > contributor_seen_timeout && !self.is_coordinator_contributor(&participant) {
                     tracing::warn!(
-                        "Dropping participant {} because it has exceeded the maximum ({:?}s) allowed time \
-                        since it was last seen by the coordinator (last seen {:?}s ago).",
+                        "Dropping participant {} because it has exceeded the maximum ({}) allowed time \
+                        since it was last seen by the coordinator (last seen {} ago).",
                         participant,
-                        contributor_seen_timeout.whole_seconds(),
-                        elapsed.whole_seconds()
+                        chrono_humanize::HumanTime::from(contributor_seen_timeout),
+                        chrono_humanize::HumanTime::from(elapsed)
                     );
                     // Drop the participant.
                     Some(self.drop_participant(participant, time))
@@ -2889,7 +2889,7 @@ impl CoordinatorState {
         // Check that the time to trigger the next round has been reached, if it is set.
         if let Some(metrics) = &self.current_metrics {
             if let Some(next_round_after) = metrics.next_round_after {
-                if time.now_utc() < next_round_after {
+                if time.utc_now() < next_round_after {
                     return Err(CoordinatorError::QueueWaitTimeIncomplete);
                 }
             }
@@ -3116,8 +3116,8 @@ impl CoordinatorState {
                 (
                     participant_info.reliability,
                     Some(participant_info.round_height),
-                    time.now_utc(),
-                    time.now_utc(),
+                    time.utc_now(),
+                    time.utc_now(),
                 ),
             );
         }
@@ -3214,7 +3214,7 @@ impl CoordinatorState {
         time: &dyn TimeSource,
     ) -> Result<(), CoordinatorError> {
         if let Some((_, _, last_seen, _)) = self.queue.get_mut(participant) {
-            *last_seen = time.now_utc();
+            *last_seen = time.utc_now();
             return Ok(());
         }
 
@@ -3240,7 +3240,7 @@ impl CoordinatorState {
         };
 
         if let Some(info) = info {
-            info.last_seen = time.now_utc();
+            info.last_seen = time.utc_now();
             Ok(())
         } else {
             Err(CoordinatorError::ParticipantNotFound(participant.clone()))
@@ -4372,7 +4372,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(OffsetDateTime::now_utc());
+        let time = MockTimeSource::new(Utc::now());
 
         let action = state.reset_current_round(false, &time).unwrap();
         assert!(!action.rollback);
@@ -4532,7 +4532,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(OffsetDateTime::now_utc());
+        let time = MockTimeSource::new(Utc::now());
 
         dbg!(&state.current_contributors());
 
@@ -4655,7 +4655,7 @@ mod tests {
 
         assert!(!state.is_current_round_finished());
 
-        let time = MockTimeSource::new(OffsetDateTime::now_utc());
+        let time = MockTimeSource::new(Utc::now());
 
         let drop = state.drop_participant(&contributor_1, &time).unwrap();
 

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -4,6 +4,7 @@ use setup_utils::{CheckForCorrectness, UseCompression};
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
+use serde_with::DurationSecondsWithFrac;
 
 type BatchSize = usize;
 type ChunkSize = usize;
@@ -224,17 +225,21 @@ pub struct Environment {
     /// Returns the maximum duration a contributor can go without
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
-    contributor_seen_timeout: time::Duration,
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    contributor_seen_timeout: chrono::Duration,
     /// The maximum duration a verifier can go without being seen by
     /// the coordinator before it will be dropped from the ceremony by
     /// the coordinator.
-    verifier_seen_timeout: time::Duration,
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    verifier_seen_timeout: chrono::Duration,
     /// The maximum duration a lock can be held by a participant
     /// before it will be dropped from the ceremony by the
     /// coordinator.
-    participant_lock_timeout: time::Duration,
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    participant_lock_timeout: chrono::Duration,
     /// The maximum duration a queued contributor can go without a heartbeat.
-    queue_seen_timeout: time::Duration,
+    #[serde_as(as = "DurationSecondsWithFrac<String>")]
+    queue_seen_timeout: chrono::Duration,
     /// The number of drops tolerated by a participant before banning them from future rounds.
     participant_ban_threshold: u16,
     /// The setting to allow current contributors to join the queue for the next round.
@@ -334,7 +339,7 @@ impl Environment {
     /// being seen by the coordinator before it will be dropped from
     /// the ceremony by the coordinator.
     ///
-    pub const fn contributor_seen_timeout(&self) -> time::Duration {
+    pub const fn contributor_seen_timeout(&self) -> chrono::Duration {
         self.contributor_seen_timeout
     }
 
@@ -343,7 +348,7 @@ impl Environment {
     /// seen by the coordinator before it will be dropped from the
     /// ceremony by the coordinator.
     ///
-    pub const fn verifier_seen_timeout(&self) -> time::Duration {
+    pub const fn verifier_seen_timeout(&self) -> chrono::Duration {
         self.verifier_seen_timeout
     }
 
@@ -352,7 +357,7 @@ impl Environment {
     /// lock before being dropped from the ceremony by the
     /// coordinator.
     ///
-    pub const fn participant_lock_timeout(&self) -> time::Duration {
+    pub const fn participant_lock_timeout(&self) -> chrono::Duration {
         self.participant_lock_timeout
     }
 
@@ -360,7 +365,7 @@ impl Environment {
     /// Returns the maximum duration that a queued contributor can go
     /// without a heartbeat.
     ///
-    pub const fn queue_seen_timeout(&self) -> time::Duration {
+    pub const fn queue_seen_timeout(&self) -> chrono::Duration {
         self.queue_seen_timeout
     }
 
@@ -520,19 +525,19 @@ impl Testing {
         deployment
     }
 
-    pub fn contributor_seen_timeout(&self, contributor_timeout: time::Duration) -> Self {
+    pub fn contributor_seen_timeout(&self, contributor_timeout: chrono::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.contributor_seen_timeout = contributor_timeout;
         deployment
     }
 
-    pub fn participant_lock_timeout(&self, participant_lock_timeout: time::Duration) -> Self {
+    pub fn participant_lock_timeout(&self, participant_lock_timeout: chrono::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.participant_lock_timeout = participant_lock_timeout;
         deployment
     }
 
-    pub fn queue_seen_timeout(&self, queue_seen_timeout: time::Duration) -> Self {
+    pub fn queue_seen_timeout(&self, queue_seen_timeout: chrono::Duration) -> Self {
         let mut deployment = self.clone();
         deployment.environment.queue_seen_timeout = queue_seen_timeout;
         deployment
@@ -570,10 +575,10 @@ impl std::default::Default for Testing {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: time::Duration::minutes(5),
-                verifier_seen_timeout: time::Duration::minutes(15),
-                participant_lock_timeout: time::Duration::minutes(20),
-                queue_seen_timeout: time::Duration::days(10),
+                contributor_seen_timeout: chrono::Duration::minutes(5),
+                verifier_seen_timeout: chrono::Duration::minutes(15),
+                participant_lock_timeout: chrono::Duration::minutes(20),
+                queue_seen_timeout: chrono::Duration::days(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -609,12 +614,12 @@ impl Development {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
@@ -686,10 +691,10 @@ impl std::default::Default for Development {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: time::Duration::minutes(1),
-                verifier_seen_timeout: time::Duration::minutes(15),
-                participant_lock_timeout: time::Duration::minutes(20),
-                queue_seen_timeout: time::Duration::minutes(10),
+                contributor_seen_timeout: chrono::Duration::minutes(1),
+                verifier_seen_timeout: chrono::Duration::minutes(15),
+                participant_lock_timeout: chrono::Duration::minutes(20),
+                queue_seen_timeout: chrono::Duration::minutes(10),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: true,
                 allow_current_verifiers_in_queue: true,
@@ -725,17 +730,17 @@ impl Production {
         self
     }
 
-    pub fn contributor_seen_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn contributor_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.contributor_seen_timeout = timeout;
         self
     }
 
-    pub fn participant_lock_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn participant_lock_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.participant_lock_timeout = timeout;
         self
     }
 
-    pub fn queue_seen_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn queue_seen_timeout(mut self, timeout: chrono::Duration) -> Self {
         self.environment.queue_seen_timeout = timeout;
         self
     }
@@ -801,10 +806,10 @@ impl std::default::Default for Production {
                 maximum_verifiers_per_round: 5,
                 contributor_lock_chunk_limit: 5,
                 verifier_lock_chunk_limit: 5,
-                contributor_seen_timeout: time::Duration::days(7),
-                verifier_seen_timeout: time::Duration::days(7),
-                participant_lock_timeout: time::Duration::days(7),
-                queue_seen_timeout: time::Duration::days(7),
+                contributor_seen_timeout: chrono::Duration::days(7),
+                verifier_seen_timeout: chrono::Duration::days(7),
+                participant_lock_timeout: chrono::Duration::days(7),
+                queue_seen_timeout: chrono::Duration::days(7),
                 participant_ban_threshold: 5,
                 allow_current_contributors_in_queue: false,
                 allow_current_verifiers_in_queue: true,

--- a/phase1-coordinator/src/testing/coordinator.rs
+++ b/phase1-coordinator/src/testing/coordinator.rs
@@ -7,12 +7,12 @@ use crate::{
     CoordinatorError,
 };
 
+use chrono::{DateTime, TimeZone, Utc};
 use once_cell::sync::Lazy;
 use serde_diff::{Diff, SerdeDiff};
 #[cfg(test)]
 use serial_test::serial;
 use std::{path::Path, sync::Arc};
-use time::{macros::datetime, OffsetDateTime};
 use tracing::*;
 
 use fs_err as fs;
@@ -27,7 +27,7 @@ pub static TEST_ENVIRONMENT: Lazy<Environment> = Lazy::new(|| Testing::from(Para
 pub static TEST_ENVIRONMENT_3: Lazy<Environment> = Lazy::new(|| Testing::from(Parameters::Test3Chunks).into());
 
 /// Round start datetime for testing purposes only.
-pub static TEST_STARTED_AT: Lazy<OffsetDateTime> = Lazy::new(|| datetime!(1970-01-01 00:01:01 UTC));
+pub static TEST_STARTED_AT: Lazy<DateTime<Utc>> = Lazy::new(|| Utc.ymd(1970, 1, 1).and_hms(0, 1, 1));
 
 /// Contributor ID for testing purposes only.
 pub static TEST_CONTRIBUTOR_ID: Lazy<Participant> =

--- a/phase1-coordinator/src/testing/resources/round.json
+++ b/phase1-coordinator/src/testing/resources/round.json
@@ -1,7 +1,7 @@
 {
     "version": 0,
     "height": 0,
-    "startedAt": 61,
+    "startedAt": "1970-01-01T00:01:01Z",
     "finishedAt": null,
     "contributorIds": [
         "0xd0FaDc3C5899c28c581c0e06819f4113cb08b0e4",

--- a/phase1-coordinator/src/testing/resources/test_round_0.json
+++ b/phase1-coordinator/src/testing/resources/test_round_0.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 0,
     "timestamp": null,
-    "startedAt": 61,
+    "startedAt": "1970-01-01T00:01:01Z",
     "finishedAt": null,
     "contributorIds": [],
     "verifierIds": [],

--- a/phase1-coordinator/src/testing/resources/test_round_1_initial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_initial.json
@@ -2,7 +2,7 @@
     "version": 1,
     "height": 1,
     "timestamp": null,
-    "startedAt": 61,
+    "startedAt": "1970-01-01T00:01:01Z",
     "finishedAt": null,
     "contributorIds": [
         "testing-coordinator-contributor.contributor"

--- a/phase1-coordinator/src/testing/resources/test_round_1_partial.json
+++ b/phase1-coordinator/src/testing/resources/test_round_1_partial.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "height": 1,
-  "startedAt": 1624382721,
+  "startedAt": "2021-06-22T17:25:21.109306563Z",
   "finishedAt": null,
   "contributorIds": [
     "testing-coordinator-contributor-3.contributor",

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -11,8 +11,8 @@ use crate::{
     Participant,
     Round,
 };
+use chrono::Utc;
 use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
-use time::OffsetDateTime;
 
 use fs_err as fs;
 use rand::RngCore;
@@ -1975,7 +1975,7 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -1987,8 +1987,8 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::minutes(5))
-        .participant_lock_timeout(time::Duration::minutes(10));
+        .contributor_seen_timeout(chrono::Duration::minutes(5))
+        .participant_lock_timeout(chrono::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2011,14 +2011,14 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // contributor to timeout)
-    time.update(|prev| prev + time::Duration::minutes(1));
+    time.update(|prev| prev + chrono::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + time::Duration::minutes(5));
+    time.update(|prev| prev + chrono::Duration::minutes(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2036,7 +2036,7 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn contributor_wait_verifier_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2047,8 +2047,8 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
         16, /* chunk_size */
     ));
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::minutes(5))
-        .participant_lock_timeout(time::Duration::minutes(8));
+        .contributor_seen_timeout(chrono::Duration::minutes(5))
+        .participant_lock_timeout(chrono::Duration::minutes(8));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
     let number_of_chunks = environment.number_of_chunks() as usize;
@@ -2071,7 +2071,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     coordinator.update()?;
 
     for _ in 0..(number_of_chunks / 2) {
-        time.update(|prev| prev + time::Duration::minutes(1));
+        time.update(|prev| prev + chrono::Duration::minutes(1));
         coordinator.contribute(&contributor1, &contributor_signing_key1, &seed1)?;
         coordinator.contribute(&contributor2, &contributor_signing_key2, &seed2)?;
     }
@@ -2085,7 +2085,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 
     // contributors are stuck waiting for 10 minutes, longer than the
     // contributor timeout duration.
-    time.update(|prev| prev + time::Duration::minutes(10));
+    time.update(|prev| prev + chrono::Duration::minutes(10));
 
     // Emulate contributor querying the current round via the
     // `/v1/round/current` endpoint.
@@ -2111,7 +2111,7 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2123,8 +2123,8 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::minutes(20))
-        .participant_lock_timeout(time::Duration::minutes(10));
+        .contributor_seen_timeout(chrono::Duration::minutes(20))
+        .participant_lock_timeout(chrono::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2151,14 +2151,14 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + time::Duration::minutes(1));
+    time.update(|prev| prev + chrono::Duration::minutes(1));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + time::Duration::minutes(10));
+    time.update(|prev| prev + chrono::Duration::minutes(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2177,7 +2177,7 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2189,8 +2189,8 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::days(20))
-        .participant_lock_timeout(time::Duration::days(20));
+        .contributor_seen_timeout(chrono::Duration::days(20))
+        .participant_lock_timeout(chrono::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2219,7 +2219,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + time::Duration::days(5));
+    time.update(|prev| prev + chrono::Duration::days(5));
     coordinator.update()?;
 
     assert_eq!(1, coordinator.current_contributors().len());
@@ -2227,7 +2227,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + time::Duration::days(10));
+    time.update(|prev| prev + chrono::Duration::days(10));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2243,7 +2243,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2255,8 +2255,8 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::days(20))
-        .participant_lock_timeout(time::Duration::days(20));
+        .contributor_seen_timeout(chrono::Duration::days(20))
+        .participant_lock_timeout(chrono::Duration::days(20));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 
@@ -2286,7 +2286,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 
     // increment the time a little bit (but not enough for the
     // lock to timeout)
-    time.update(|prev| prev + time::Duration::days(5));
+    time.update(|prev| prev + chrono::Duration::days(5));
     coordinator.update()?;
 
     // Send heartbeat from contributor2
@@ -2297,7 +2297,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     assert!(coordinator.dropped_participants().is_empty());
 
     // push the time past the timout
-    time.update(|prev| prev + time::Duration::days(5));
+    time.update(|prev| prev + chrono::Duration::days(5));
     coordinator.update()?;
 
     // Check that replacement contributor has been added, and that the
@@ -2315,7 +2315,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 #[test]
 #[serial]
 fn rollback_locked_chunk() -> anyhow::Result<()> {
-    let time = Arc::new(MockTimeSource::new(OffsetDateTime::now_utc()));
+    let time = Arc::new(MockTimeSource::new(Utc::now()));
 
     let parameters = Parameters::Custom(Settings::new(
         ContributionMode::Chunked,
@@ -2327,8 +2327,8 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
     ));
 
     let testing_deployment: Testing = Testing::from(parameters)
-        .contributor_seen_timeout(time::Duration::minutes(20))
-        .participant_lock_timeout(time::Duration::minutes(10));
+        .contributor_seen_timeout(chrono::Duration::minutes(20))
+        .participant_lock_timeout(chrono::Duration::minutes(10));
 
     let environment = initialize_test_environment(&Environment::from(testing_deployment));
 


### PR DESCRIPTION
Reverts AleoHQ/aleo-setup#446

Using `time` broke too much of the surrounding dependencies of the setup, so the simplest option right now is to revert it.