### PR TITLE
phase1-wasm request coordinator public settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,7 @@ dependencies = [
 name = "phase1-wasm"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "blake2",
  "bytes",
  "cfg-if",
@@ -1874,8 +1875,10 @@ dependencies = [
  "snarkvm-dpc 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
  "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=setup_wasm)",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,10 +1863,12 @@ dependencies = [
  "bytes",
  "cfg-if",
  "console_error_panic_hook",
+ "console_log",
  "getrandom 0.2.3",
  "hex",
  "http",
  "js-sys",
+ "log",
  "oneshot",
  "phase1",
  "rand 0.8.4",

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -1,5 +1,5 @@
 use crate::{objects::Participant, storage::Disk};
-use phase1::{helpers::CurveKind, ContributionMode, ProvingSystem};
+use phase1::{chunk_size, helpers::CurveKind, total_size_in_g1, ContributionMode, ProvingSystem};
 use setup_utils::{CheckForCorrectness, UseCompression};
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};

--- a/phase1-coordinator/src/macros.rs
+++ b/phase1-coordinator/src/macros.rs
@@ -59,26 +59,6 @@ macro_rules! verified_contribution_size {
     }};
 }
 
-/// Returns the total number of powers of tau G1 given a proving system and the number of powers.
-#[macro_export]
-macro_rules! total_size_in_g1 {
-    ($proving_system:ident, $power:ident) => {{
-        use phase1::ProvingSystem;
-
-        match $proving_system {
-            ProvingSystem::Groth16 => ((1 << ($power + 1)) - 1),
-            ProvingSystem::Marlin => (1 << $power),
-        }
-    }};
-}
-
-/// Returns the chunk size given the desired number of chunks, the proving system,
-/// and the number of powers.
-#[macro_export]
-macro_rules! chunk_size {
-    ($num_chunks:ident, $proving_system:ident, $power:ident) => {{ ((total_size_in_g1!($proving_system, $power) + $num_chunks - 1) / $num_chunks) }};
-}
-
 /// Returns the final round filesize given an instantiation of `PairingEngine`,
 /// an instance of `Settings`, and a compressed setting.
 #[macro_export]

--- a/phase1-wasm/Cargo.toml
+++ b/phase1-wasm/Cargo.toml
@@ -25,11 +25,13 @@ snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"
 blake2 = { version = "0.9", default-features = false }
 bytes = "1.1"
 cfg-if = "1.0"
+console_log = "0.2"
 hex = { version = "0.4" }
 getrandom = { version = "0.2" }
 oneshot = "0.1"
 rand = { version = "0.8" }
 js-sys = "0.3.45"
+log = "0.4"
 rand_chacha = { version = "0.3" }
 rayon = "1.1.0"
 rayon-core = "1.5.0"
@@ -50,7 +52,7 @@ web-sys = { version = "0.3", features = ["console", "ErrorEvent", "Event", "Navi
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6" }
+console_error_panic_hook = { version = "0.1.7" }
 
 [dev-dependencies]
 rand_chacha = { version = "0.3" }

--- a/phase1-wasm/Cargo.toml
+++ b/phase1-wasm/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+anyhow = "1.0"
 http = "0.2"
 phase1 = { path = "../phase1", default-features = false }
 setup-utils = { path = "../setup-utils", default-features = false }
@@ -37,8 +38,10 @@ serde = { version = "1.0.114" }
 serde_derive = { version = "1.0.114" }
 serde_json = "1.0"
 serde-diff = { version = "0.4" }
+thiserror = "1.0"
 tracing = { version = "0.1.21" }
 tracing-subscriber = { version = "0.3" }
+url = "2.2"
 wasm-bindgen = { version = "0.2.78", features=["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["console", "ErrorEvent", "Event", "Navigator", "Window", "Worker", "DedicatedWorkerGlobalScope", "MessageEvent", "Response"] }

--- a/phase1-wasm/src/contributor.rs
+++ b/phase1-wasm/src/contributor.rs
@@ -23,6 +23,15 @@ const INNER_SETTINGS: Settings = Settings {
     chunk_size: 32768,
 };
 
+// Development ceremony parameters
+const DEVELOPMENT_SETTINGS: Settings = Settings {
+    curve_kind: "bls12_377",
+    proving_system: "groth16",
+    batch_size: 512,
+    power: 16,
+    chunk_size: 2048,
+};
+
 const DELAY_FIVE_SECONDS: i32 = 5000;
 const DELAY_THIRTY_SECONDS: i32 = 30000;
 const DEFAULT_THREAD_COUNT: usize = 8;
@@ -45,7 +54,9 @@ pub async fn contribute(server_url: String, private_key: String, confirmation_ke
     let mut rng = rand::thread_rng();
     let private_key = PrivateKey::from_str(&private_key).map_err(map_js_err_dbg)?;
 
+    log::info!("Requesting coordinator settings...");
     let public_settings = request_coordinator_public_settings_retry(&server_url).await?;
+    log::info!("Coordinator settinngs: {:#?}", public_settings);
 
     if public_settings.check_reliability {
         return Err(map_js_err(anyhow::anyhow!(
@@ -55,6 +66,7 @@ pub async fn contribute(server_url: String, private_key: String, confirmation_ke
 
     let settings = match public_settings.setup {
         SetupKind::Inner => &INNER_SETTINGS,
+        SetupKind::Development => &DEVELOPMENT_SETTINGS,
         _ => {
             return Err(map_js_err(anyhow::anyhow!(
                 "Unsupported setup kind: {:?}",

--- a/phase1-wasm/src/contributor.rs
+++ b/phase1-wasm/src/contributor.rs
@@ -53,6 +53,7 @@ pub async fn contribute(server_url: String, private_key: String, confirmation_ke
 
     let settings = match public_settings.setup {
         SetupKind::Inner => &INNER_SETTINGS,
+        SetupKind::Development => &INNER_SETTINGS,
         _ => {
             return Err(map_js_err(anyhow::anyhow!(
                 "Unsupported setup kind: {:?}",
@@ -123,7 +124,7 @@ async fn attempt_contribution<R: Rng + CryptoRng>(
 
     web_sys::console::log_1(&"contributing...".into());
     let result = Phase1WASM::contribute_chunked(
-        &INNER_SETTINGS,
+        settings,
         response.chunk_id as usize,
         seed,
         chunk_bytes.to_vec(),

--- a/phase1-wasm/src/errors.rs
+++ b/phase1-wasm/src/errors.rs
@@ -1,16 +1,15 @@
+use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Error)]
 pub enum ContributeError {
+    #[error("Challenge hash size is invalid")]
     ChallengeHashSizeInvalid,
+    #[error("Response hash size is invalid")]
     ResponseHashSizeInvalid,
+    #[error("Next challenge hash size is invalid")]
     NextChallengeHashSizeInvalid,
+    #[error("Contribution signature size does not match")]
     ContributionSignatureSizeMismatch,
-}
-
-impl From<ContributeError> for JsValue {
-    fn from(value: ContributeError) -> Self {
-        JsValue::from_str(&format!("{:?}", value))
-    }
 }

--- a/phase1-wasm/src/phase1.rs
+++ b/phase1-wasm/src/phase1.rs
@@ -46,6 +46,15 @@ pub fn init_hooks() {
 pub struct Phase1WASM {}
 
 #[cfg(not(test))]
+pub struct Settings {
+    pub curve_kind: &'static str,
+    pub proving_system: &'static str,
+    pub batch_size: usize,
+    pub power: usize,
+    pub chunk_size: usize,
+}
+
+#[cfg(not(test))]
 impl Phase1WASM {
     pub fn contribute_full(
         curve_kind: &str,
@@ -71,17 +80,20 @@ impl Phase1WASM {
     }
 
     pub fn contribute_chunked(
-        curve_kind: &'static str,
-        proving_system: &str,
-        batch_size: usize,
-        power: usize,
+        settings: &Settings,
         chunk_index: usize,
-        chunk_size: usize,
         seed: &[u8],
         challenge: Vec<u8>,
         worker: &crate::pool::WorkerProcess,
         thread_pool_size: usize,
     ) -> anyhow::Result<ContributionResponse> {
+        let Settings {
+            curve_kind,
+            proving_system,
+            batch_size,
+            power,
+            chunk_size,
+        } = *settings;
         // Configure a rayon thread pool which will pull web workers from `pool`.
         let thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(thread_pool_size)

--- a/phase1-wasm/src/requests.rs
+++ b/phase1-wasm/src/requests.rs
@@ -1,8 +1,9 @@
 use crate::utils::*;
 use js_sys::{Promise, Uint8Array};
 use rand::{CryptoRng, Rng};
-use setup1_shared::structures::LockResponse;
+use setup1_shared::structures::{LockResponse, PublicSettings};
 use snarkvm_dpc::{parameters::testnet2::Testnet2Parameters, PrivateKey};
+use url::Url;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
@@ -27,61 +28,89 @@ extern "C" {
 pub async fn post_join_queue<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
     confirmation_key: &str,
-    server_url: String,
+    server_url: &Url,
     rng: &mut R,
-) -> Result<bool, JsValue> {
+) -> anyhow::Result<bool> {
     let join_queue_path = format!("/v1/queue/contributor/join/{}/{}/{}", MAJOR, MINOR, PATCH);
-    let mut join_queue_url = server_url.clone();
-    join_queue_url.push_str(&join_queue_path);
+    let join_queue_url = server_url.join(&join_queue_path)?;
     let authorization = get_authorization_value(private_key, "POST", &join_queue_path, rng)?;
 
-    let bytes = serde_json::to_vec(confirmation_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+    let bytes = serde_json::to_vec(confirmation_key)?;
 
     let mut opts = RequestInit::new();
     opts.method("POST");
     opts.mode(RequestMode::Cors);
     opts.body(Some(&js_sys::Uint8Array::from(bytes.as_slice()).into()));
 
-    let request = Request::new_with_str_and_init(&join_queue_url, &opts)?;
+    let request = Request::new_with_str_and_init(join_queue_url.as_ref(), &opts)
+        .map_err(|e| anyhow::anyhow!("Error creating request: {:?}", e))?;
 
-    request.headers().set("Authorization", &authorization)?;
-    request.headers().set("Content-Length", &format!("{}", bytes.len()))?;
-    request.headers().set("Content-Type", "application/json")?;
+    request
+        .headers()
+        .set("Authorization", &authorization)
+        .map_err(|e| anyhow::anyhow!("Error setting Authorization header: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Length", &format!("{}", bytes.len()))
+        .map_err(|e| anyhow::anyhow!("Error setting Content-Length header: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| anyhow::anyhow!("Error setting Content-Type header: {:?}", e))?;
 
-    let response = JsFuture::from(fetch_with_request(&request)).await?;
+    let response = JsFuture::from(fetch_with_request(&request))
+        .await
+        .map_err(|e| anyhow::anyhow!("Error creating JsFuture: {:?}", e))?;
 
     let response: Response = response.dyn_into().unwrap();
-    let data = JsFuture::from(response.json()?).await?;
+    let data = JsFuture::from(
+        response
+            .json()
+            .map_err(|e| anyhow::anyhow!("Error converting response to json: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Error creating JsFuture from response {:?}", e))?;
     let joined: bool = data.into_serde().unwrap();
     Ok(joined)
+}
+
+pub async fn request_coordinator_public_settings(server_url: String) -> Result<PublicSettings, JsValue> {
+    let settings_path = "/v1/coordinator/settings";
+    let mut settings_url = server_url.clone();
+    settings_url.push_str(&settings_path);
+
+    let client = reqwest::Client::new();
+    let bytes = client
+        .post(settings_url)
+        .header(http::header::CONTENT_LENGTH, 0)
+        .send()
+        .await?
+        .bytes()
+        .await?;
+    PublicSettings::decode(&bytes.to_vec()).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Send a heartbeat to the coordinator, signaling that the contributor is still
 /// online.
 pub async fn post_heartbeat<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     rng: &mut R,
-) -> Result<(), JsValue> {
+) -> anyhow::Result<()> {
     let heartbeat_path = "/v1/contributor/heartbeat";
-    let mut heartbeat_url = server_url.clone();
-    heartbeat_url.push_str(&heartbeat_path);
+    let heartbeat_url = server_url.join(heartbeat_path)?;
     let client = reqwest::Client::new();
     let authorization = get_authorization_value(private_key, "POST", &heartbeat_path, rng)?;
 
     let response = client
-        .post(&heartbeat_url)
+        .post(heartbeat_url)
         .header(http::header::AUTHORIZATION, authorization)
         .header(http::header::CONTENT_LENGTH, 0)
         .send()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+        .await?
+        .error_for_status()?;
 
-    response
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    response.error_for_status()?;
 
     Ok(())
 }
@@ -90,30 +119,24 @@ pub async fn post_heartbeat<R: Rng + CryptoRng>(
 /// gauge when the contributor is finished.
 pub async fn get_tasks_left<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     rng: &mut R,
-) -> Result<bool, JsValue> {
+) -> anyhow::Result<bool> {
     let task_path = "/v1/contributor/get_task";
-    let mut task_url = server_url.clone();
-    task_url.push_str(&task_path);
+    let task_url = server_url.join(task_path)?;
     let client = reqwest::Client::new();
     let authorization = get_authorization_value(private_key, "GET", &task_path, rng)?;
 
     let response = client
-        .post(&task_url)
+        .post(task_url)
         .header(http::header::AUTHORIZATION, authorization)
         .header(http::header::CONTENT_LENGTH, 0)
         .send()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+        .await?
+        .error_for_status()?;
 
-    let data = response
-        .bytes()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
-    let tasks_left = serde_json::from_slice::<bool>(&*data).map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    let data = response.bytes().await?;
+    let tasks_left = serde_json::from_slice::<bool>(&*data)?;
 
     Ok(tasks_left)
 }
@@ -123,31 +146,24 @@ pub async fn get_tasks_left<R: Rng + CryptoRng>(
 /// to be downloaded.
 pub async fn post_lock_chunk<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     rng: &mut R,
-) -> Result<LockResponse, JsValue> {
+) -> anyhow::Result<LockResponse> {
     let lock_path = "/v1/contributor/try_lock";
-    let mut lock_url = server_url.clone();
-    lock_url.push_str(&lock_path);
+    let lock_url = server_url.join(lock_path)?;
     let client = reqwest::Client::new();
     let authorization = get_authorization_value(private_key, "POST", &lock_path, rng)?;
 
     let response = client
-        .post(&lock_url)
+        .post(lock_url)
         .header(http::header::AUTHORIZATION, authorization)
         .header(http::header::CONTENT_LENGTH, 0)
         .send()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+        .await?
+        .error_for_status()?;
 
-    let data = response
-        .bytes()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
-    let lock_response =
-        serde_json::from_slice::<LockResponse>(&*data).map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    let data = response.bytes().await?;
+    let lock_response = serde_json::from_slice::<LockResponse>(&*data)?;
 
     Ok(lock_response)
 }
@@ -160,21 +176,20 @@ pub async fn post_lock_chunk<R: Rng + CryptoRng>(
 /// serialization procedures and allows us to deliver the payload properly.
 pub async fn get_challenge<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     chunk_id: u64,
     contribution_id: u64,
     rng: &mut R,
 ) -> Result<Vec<u8>, JsValue> {
     let download_path = format!("/v1/download/challenge/{}/{}", chunk_id, contribution_id);
-    let mut download_url = server_url.clone();
-    download_url.push_str(&download_path);
-    let authorization = get_authorization_value(private_key, "GET", &download_path, rng)?;
+    let download_url = server_url.clone();
+    let authorization = get_authorization_value(private_key, "GET", &download_path, rng).map_err(map_js_err)?;
 
     let mut opts = RequestInit::new();
     opts.method("GET");
     opts.mode(RequestMode::Cors);
 
-    let request = Request::new_with_str_and_init(&download_url, &opts)?;
+    let request = Request::new_with_str_and_init(download_url.as_ref(), &opts)?;
 
     request.headers().set("Authorization", &authorization)?;
 
@@ -193,15 +208,14 @@ pub async fn get_challenge<R: Rng + CryptoRng>(
 /// serialization procedures and allows us to deliver the payload properly.
 pub async fn post_response<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     chunk_id: u64,
     contribution_id: u64,
     sig_and_result_bytes: Vec<u8>,
     rng: &mut R,
-) -> Result<(), JsValue> {
+) -> anyhow::Result<()> {
     let upload_path = format!("/v1/upload/response/{}/{}", chunk_id, contribution_id);
-    let mut upload_url = server_url.clone();
-    upload_url.push_str(&upload_path);
+    let upload_url = server_url.join(&upload_path)?;
     let authorization = get_authorization_value(private_key, "POST", &upload_path, rng)?;
 
     let mut opts = RequestInit::new();
@@ -209,15 +223,25 @@ pub async fn post_response<R: Rng + CryptoRng>(
     opts.mode(RequestMode::Cors);
     opts.body(Some(&js_sys::Uint8Array::from(sig_and_result_bytes.as_slice()).into()));
 
-    let request = Request::new_with_str_and_init(&upload_url, &opts)?;
+    let request = Request::new_with_str_and_init(upload_url.as_ref(), &opts)
+        .map_err(|e| anyhow::anyhow!("Error creating request: {:?}", e))?;
 
-    request.headers().set("Authorization", &authorization)?;
     request
         .headers()
-        .set("Content-Length", &format!("{}", sig_and_result_bytes.len()))?;
-    request.headers().set("Content-Type", "application/octet-stream")?;
+        .set("Authorization", &authorization)
+        .map_err(|e| anyhow::anyhow!("Error setting Authorization header: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Length", &format!("{}", sig_and_result_bytes.len()))
+        .map_err(|e| anyhow::anyhow!("Error setting Content-Length header: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Type", "application/octet-stream")
+        .map_err(|e| anyhow::anyhow!("Error setting Content-Type header: {:?}", e))?;
 
-    let _response = JsFuture::from(fetch_with_request(&request)).await?;
+    let _response = JsFuture::from(fetch_with_request(&request))
+        .await
+        .map_err(|e| anyhow::anyhow!("Error fetching with request: {:?}", e))?;
 
     Ok(())
 }
@@ -226,29 +250,24 @@ pub async fn post_response<R: Rng + CryptoRng>(
 /// unlock the given chunk and allow the contributor to take on a new task.
 pub async fn post_contribution<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
-    server_url: String,
+    server_url: &Url,
     chunk_id: u64,
     rng: &mut R,
-) -> Result<(), JsValue> {
+) -> anyhow::Result<()> {
     let contribute_path = format!("/v1/contributor/try_contribute/{}", chunk_id);
-    let mut contribute_url = server_url.clone();
-    contribute_url.push_str(&contribute_path);
+    let contribute_url = server_url.join(&contribute_path)?;
     let client = reqwest::Client::new();
     let authorization = get_authorization_value(private_key, "POST", &contribute_path, rng)?;
 
     let response = client
-        .post(&contribute_url)
+        .post(contribute_url)
         .header(http::header::AUTHORIZATION, authorization)
         .header(http::header::CONTENT_LENGTH, 0)
         .send()
-        .await
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+        .await?
+        .error_for_status()?;
 
-    response
-        .error_for_status()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+    response.error_for_status()?;
 
     Ok(())
 }

--- a/phase1-wasm/src/requests.rs
+++ b/phase1-wasm/src/requests.rs
@@ -69,15 +69,14 @@ pub async fn post_join_queue<R: Rng + CryptoRng>(
             .map_err(|e| anyhow::anyhow!("Error converting response to json: {:?}", e))?,
     )
     .await
-    .map_err(|e| anyhow::anyhow!("Error creating JsFuture from response {:?}", e))?;
+    .map_err(|e| anyhow::anyhow!("{:?}", e))?;
     let joined: bool = data.into_serde().unwrap();
     Ok(joined)
 }
 
-pub async fn request_coordinator_public_settings(server_url: String) -> Result<PublicSettings, JsValue> {
+pub async fn request_coordinator_public_settings(server_url: &Url) -> anyhow::Result<PublicSettings> {
     let settings_path = "/v1/coordinator/settings";
-    let mut settings_url = server_url.clone();
-    settings_url.push_str(&settings_path);
+    let settings_url = server_url.join(settings_path)?;
 
     let client = reqwest::Client::new();
     let bytes = client
@@ -87,7 +86,7 @@ pub async fn request_coordinator_public_settings(server_url: String) -> Result<P
         .await?
         .bytes()
         .await?;
-    PublicSettings::decode(&bytes.to_vec()).map_err(|e| JsValue::from_str(&e.to_string()))
+    Ok(PublicSettings::decode(&bytes.to_vec())?)
 }
 
 /// Send a heartbeat to the coordinator, signaling that the contributor is still

--- a/phase1-wasm/src/requests.rs
+++ b/phase1-wasm/src/requests.rs
@@ -181,7 +181,7 @@ pub async fn get_challenge<R: Rng + CryptoRng>(
     rng: &mut R,
 ) -> Result<Vec<u8>, JsValue> {
     let download_path = format!("/v1/download/challenge/{}/{}", chunk_id, contribution_id);
-    let download_url = server_url.clone();
+    let download_url = server_url.join(&download_path).map_err(map_js_err)?;
     let authorization = get_authorization_value(private_key, "GET", &download_path, rng).map_err(map_js_err)?;
 
     let mut opts = RequestInit::new();

--- a/phase1-wasm/src/structures.rs
+++ b/phase1-wasm/src/structures.rs
@@ -2,8 +2,6 @@ use crate::errors::ContributeError;
 use serde::{Deserialize, Serialize};
 use serde_diff::SerdeDiff;
 
-use wasm_bindgen::prelude::*;
-
 ///
 /// The contribution state for a given chunk ID that is signed by the participant.
 ///

--- a/phase1-wasm/src/structures.rs
+++ b/phase1-wasm/src/structures.rs
@@ -56,8 +56,8 @@ impl ContributionState {
     }
 
     /// Returns the message that should be signed for the `ContributionFileSignature`.
-    pub fn signature_message(&self) -> Result<String, JsValue> {
-        Ok(serde_json::to_string(&self).map_err(|e| JsValue::from_str(&format!("{}", e)))?)
+    pub fn signature_message(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string(&self)?)
     }
 }
 
@@ -74,14 +74,10 @@ pub struct ContributionFileSignature {
 
 impl ContributionFileSignature {
     /// Creates a new instance of `ContributionFileSignature`.
-    pub fn new(signature: String, state: ContributionState) -> Result<Self, JsValue> {
+    pub fn new(signature: String, state: ContributionState) -> anyhow::Result<Self> {
         tracing::debug!("Starting to create contribution signature");
         // Check that the signature is 64 bytes.
-        if hex::decode(&signature)
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
-            .len()
-            != 64
-        {
+        if hex::decode(&signature)?.len() != 64 {
             return Err(ContributeError::ContributionSignatureSizeMismatch.into());
         }
         tracing::debug!("Completed creating contribution signature");

--- a/phase1-wasm/src/utils.rs
+++ b/phase1-wasm/src/utils.rs
@@ -6,26 +6,28 @@ use snarkvm_utilities::ToBytes;
 use std::convert::TryFrom;
 use wasm_bindgen::prelude::*;
 
+/// Map an error that implements [std::fmt::Display] to a [JsValue].
+pub(crate) fn map_js_err(e: impl std::fmt::Display) -> JsValue {
+    JsValue::from_str(&format!("{}", e))
+}
+
+/// Map an error that implements [std::fmt::Debug] to a [JsValue].
+pub(crate) fn map_js_err_dbg(e: impl std::fmt::Debug) -> JsValue {
+    JsValue::from_str(&format!("{:?}", e))
+}
+
 /// Construct the authentication string for requests made to the coordinator.
 pub fn get_authorization_value<R: Rng + CryptoRng>(
     private_key: &PrivateKey<Testnet2Parameters>,
     method: &str,
     path: &str,
     rng: &mut R,
-) -> Result<String, JsValue> {
-    let view_key = ViewKey::try_from(private_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
-    let address = Address::try_from(private_key)
-        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
-        .to_string();
+) -> anyhow::Result<String> {
+    let view_key = ViewKey::try_from(private_key)?;
+    let address = Address::try_from(private_key)?.to_string();
 
     let message = format!("{} {}", method.to_lowercase(), path.to_lowercase());
-    let signature = hex::encode(
-        &view_key
-            .sign(message.as_bytes(), rng)
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
-            .to_bytes_le()
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?,
-    );
+    let signature = hex::encode(&view_key.sign(message.as_bytes(), rng)?.to_bytes_le()?);
 
     let authorization = format!("Aleo {}:{}", address, signature);
     Ok(authorization)
@@ -37,25 +39,15 @@ pub fn sign_contribution_state<R: Rng + CryptoRng>(
     response_hash: &[u8],
     next_challenge_hash: Option<Vec<u8>>,
     rng: &mut R,
-) -> Result<ContributionFileSignature, JsValue> {
+) -> anyhow::Result<ContributionFileSignature> {
     let contribution_state =
-        ContributionState::new(challenge_hash.to_vec(), response_hash.to_vec(), next_challenge_hash)
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
-    let message = contribution_state
-        .signature_message()
-        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+        ContributionState::new(challenge_hash.to_vec(), response_hash.to_vec(), next_challenge_hash)?;
+    let message = contribution_state.signature_message()?;
 
-    let view_key = ViewKey::try_from(signing_key).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
-    let signature = hex::encode(
-        &view_key
-            .sign(message.as_bytes(), rng)
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?
-            .to_bytes_le()
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?,
-    );
+    let view_key = ViewKey::try_from(signing_key)?;
+    let signature = hex::encode(&view_key.sign(message.as_bytes(), rng)?.to_bytes_le()?);
 
-    let contribution_file_signature = ContributionFileSignature::new(signature, contribution_state)
-        .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+    let contribution_file_signature = ContributionFileSignature::new(signature, contribution_state)?;
 
     Ok(contribution_file_signature)
 }

--- a/phase1-wasm/src/utils.rs
+++ b/phase1-wasm/src/utils.rs
@@ -8,7 +8,9 @@ use wasm_bindgen::prelude::*;
 
 /// Map an error that implements [std::fmt::Display] to a [JsValue].
 pub(crate) fn map_js_err(e: impl std::fmt::Display) -> JsValue {
-    JsValue::from_str(&format!("{}", e))
+    // Use alternate selector # to activate anyhow::Error inclusion of causes.
+    // See https://docs.rs/anyhow/1.0.26/anyhow/struct.Error.html#display-representations
+    JsValue::from_str(&format!("{:#}", e))
 }
 
 /// Map an error that implements [std::fmt::Debug] to a [JsValue].

--- a/phase1/src/lib.rs
+++ b/phase1/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod helpers;
+pub mod macros;
 
 pub mod objects;
 pub use objects::*;

--- a/phase1/src/macros.rs
+++ b/phase1/src/macros.rs
@@ -1,0 +1,21 @@
+//! Macros for use with this crate.
+
+/// Returns the total number of powers of tau G1 given a proving system and the number of powers.
+#[macro_export]
+macro_rules! total_size_in_g1 {
+    ($proving_system:ident, $power:ident) => {{
+        use $crate::ProvingSystem;
+
+        match $proving_system {
+            ProvingSystem::Groth16 => ((1 << ($power + 1)) - 1),
+            ProvingSystem::Marlin => (1 << $power),
+        }
+    }};
+}
+
+/// Returns the chunk size given the desired number of chunks, the proving system,
+/// and the number of powers.
+#[macro_export]
+macro_rules! chunk_size {
+    ($num_chunks:ident, $proving_system:ident, $power:ident) => {{ (($crate::total_size_in_g1!($proving_system, $power) + $num_chunks - 1) / $num_chunks) }};
+}


### PR DESCRIPTION
+ Implement requesting of the coordinator public settings for `phase1-wasm`, now there is a nice error message if you try running the browser with an unsupported setup. 
+ Support for development environment in `phase1-wasm` (browser testing runs very fast now!)
+ Refactor error handling in `phase1-wasm` to use `anyhow` more and reduce clutter.
+ Use the `console_log` crate for improved logging.